### PR TITLE
Add requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+astropy
+numpy
+tqdm
+watchdog
+pyqt5
+astroalign
+opencv-python


### PR DESCRIPTION
Eases the installation of dependencies with pip. Simply use (whether you use a venv or not) :
$ pip install -r requirements.txt