### PR TITLE
Wait for files to be fully written to disk during new image scan

### DIFF
--- a/als.py
+++ b/als.py
@@ -101,21 +101,23 @@ class MyEventHandler(FileSystemEventHandler, QtCore.QThread, image_ref_save):
 
     @log
     def on_created(self, event):
-        # if not event.is_directory:
         if event.event_type == 'created':
             file_is_incomplete = True
             last_file_size = -1
             file_path = event.src_path
+            _logger.debug(f"New image file detected : {file_path}. Waiting untill file is fully written to disk...")
 
             while file_is_incomplete:
                 info = QFileInfo(file_path)
                 size = info.size()
+                _logger.debug(f"File {file_path}'s size = {size}")
                 if size == last_file_size:
                     file_is_incomplete = False
+                    _logger.debug(f"File {file_path} has been fully written to disk")
                 last_file_size = size
                 self.msleep(DEFAULT_SCAN_SIZE_RETRY_PERIOD_MS)
 
-            print("New image arrive: %s" % file_path)
+            _logger.info(f"New image ready to be processed : {file_path}")
             self.new_image_path = file_path
             self.created_signal.emit()
 

--- a/als.py
+++ b/als.py
@@ -27,7 +27,7 @@ from http.server import HTTPServer as BaseHTTPServer, SimpleHTTPRequestHandler
 
 import numpy as np
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import pyqtSlot, Qt
+from PyQt5.QtCore import pyqtSlot, QFileInfo, Qt
 from astropy.io import fits
 from qimage2ndarray import array2qimage
 from watchdog.events import FileSystemEventHandler
@@ -43,6 +43,7 @@ name_of_tiff_image = "stack_image.tiff"
 name_of_jpeg_image = "stack_image.jpg"
 gettext.install('als', 'locale')
 save_type = "jpeg"
+DEFAULT_SCAN_SIZE_RETRY_PERIOD_MS = 100
 
 _logger = logging.getLogger(__name__)
 
@@ -102,8 +103,20 @@ class MyEventHandler(FileSystemEventHandler, QtCore.QThread, image_ref_save):
     def on_created(self, event):
         # if not event.is_directory:
         if event.event_type == 'created':
-            _logger.info(f"New image arrived : {event.src_path}")
-            self.new_image_path = event.src_path
+            file_is_incomplete = True
+            last_file_size = -1
+            file_path = event.src_path
+
+            while file_is_incomplete:
+                info = QFileInfo(file_path)
+                size = info.size()
+                if size == last_file_size:
+                    file_is_incomplete = False
+                last_file_size = size
+                self.msleep(DEFAULT_SCAN_SIZE_RETRY_PERIOD_MS)
+
+            print("New image arrive: %s" % file_path)
+            self.new_image_path = file_path
             self.created_signal.emit()
 
 


### PR DESCRIPTION
Fixes Issue #18

To be sure that an image file has been completely written to disk before we notify the image processors, we check the new file's size repeatedly and consider it complete when two size scans give the same value

This has been tested OK when simulating a slow file copy with `dd`