### PR TITLE
Perform all image disk saves in the background

### DIFF
--- a/src/als/als.py
+++ b/src/als/als.py
@@ -33,7 +33,6 @@ import numpy as np
 from PyQt5.QtCore import pyqtSignal, QFileInfo, QThread, Qt, pyqtSlot, QTimer, QEvent
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QMainWindow, QApplication
-
 from astroalign import MaxIterError
 from qimage2ndarray import array2qimage
 from watchdog.events import FileSystemEventHandler
@@ -790,10 +789,14 @@ class MainWindow(QMainWindow):
     @log
     def _setup_work_folder(self):
         """Prepares the work folder."""
+
         work_dir_path = config.get_work_folder_path()
         resources_dir_path = os.path.dirname(os.path.realpath(__file__)) + "/../resources"
+
         shutil.copy(resources_dir_path + "/index.html", work_dir_path)
-        shutil.copy(resources_dir_path + "/waiting.jpg", work_dir_path + "/" + config.WEB_SERVED_IMAGE_FILE_NAME_BASE + ".jpg")
+
+        standby_image_path = work_dir_path + "/" + config.WEB_SERVED_IMAGE_FILE_NAME_BASE + '.' + config.IMAGE_SAVE_JPEG
+        shutil.copy(resources_dir_path + "/waiting.jpg", standby_image_path)
 
     @pyqtSlot(name="on_pbStop_clicked")
     @log

--- a/src/als/als.py
+++ b/src/als/als.py
@@ -258,7 +258,6 @@ class WatchOutForFileCreations(QThread):
                 self.image_ref_save.image = self.first_image
 
                 self.image_ref_save.stack_image = prepro.post_process_image(self.image_ref_save.image,
-                                                                            self.log,
                                                                             mode=mode, scnr_on=self.scnr_on.isChecked(),
                                                                             wavelets_on=self.wavelets_on.isChecked(),
                                                                             wavelets_type=str(self.wavelets_type.currentText()),
@@ -326,7 +325,6 @@ class WatchOutForFileCreations(QThread):
                     return
 
                 self.image_ref_save.stack_image = prepro.post_process_image(self.image_ref_save.image,
-                                                                            self.log,
                                                                             mode=mode, scnr_on=self.scnr_on.isChecked(),
                                                                             wavelets_on=self.wavelets_on.isChecked(),
                                                                             wavelets_type=str(self.wavelets_type.currentText()),
@@ -571,7 +569,7 @@ class MainWindow(QMainWindow):
         else:
             raise ValueError(_("fit format not supported"))
 
-        self.image_ref_save.stack_image = prepro.post_process_image(self.image_ref_save.image, self._ui.log,
+        self.image_ref_save.stack_image = prepro.post_process_image(self.image_ref_save.image,
                                                                     mode=mode,
                                                                     scnr_on=self._ui.cbSCNR.isChecked(),
                                                                     wavelets_on=self._ui.cbWavelets.isChecked(),

--- a/src/als/als.py
+++ b/src/als/als.py
@@ -405,7 +405,7 @@ class MainWindow(QMainWindow):
 
         self._image_saver = ImageSaver()
         self._image_saver.save_successful_signal[str].connect(self.on_image_save_success)
-        self._image_saver.save_fail_signal[str].connect(self.on_image_save_failure)
+        self._image_saver.save_fail_signal[str, str].connect(self.on_image_save_failure)
         self._image_saver.start()
 
     @log
@@ -752,23 +752,26 @@ class MainWindow(QMainWindow):
 
         model.STORE.scan_in_progress = True
 
-    def on_image_save_success(self, message):
+    def on_image_save_success(self, image_path):
         """
         Qt slot for successful image save
 
-        :param message: the message to display
-        :type message: str
+        :param image_path: the path of saved image
+        :type image_path: str
         """
-        self._ui.log.append(message)
+        self._ui.log.append(f"Saved image : {image_path}")
 
-    def on_image_save_failure(self, message):
+    def on_image_save_failure(self, image_path, details):
         """
         Qt slot for failed image save
 
-        :param message: the message to display
-        :type message: str
+        :param image_path: path that couldn't be saved to
+        :type image_path: str
+
+        :param details: details on save failure
+        :type details: str
         """
-        self._ui.log.append(message)
+        self._ui.log.append(f"ERROR : Failed to save image {image_path} : {details}")
 
     @log
     def update_store_display(self):

--- a/src/als/als.py
+++ b/src/als/als.py
@@ -39,7 +39,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from als import config, preprocess as prepro, stack as stk, model
-from als.code_utilities import log
+from als.code_utilities import log, Timer
 from als.io.output import ImageSaver, save_image
 from als.model import VERSION, STORE
 from als.ui.dialogs import PreferencesDialog, question, error_box, warning_box, AboutDialog
@@ -959,18 +959,19 @@ def save_stack_result(image):
 
 def main():
     """app launcher"""
-    app = QApplication(sys.argv)
+    with Timer() as startup:
+        app = QApplication(sys.argv)
 
-    config.setup()
+        config.setup()
 
-    _LOGGER.debug("Building and showing main window")
-    window = MainWindow()
-    config.register_log_receiver(window)
-    (x, y, width, height) = config.get_window_geometry()
-    window.setGeometry(x, y, width, height)
-    window.show()
+        _LOGGER.debug("Building and showing main window")
+        window = MainWindow()
+        config.register_log_receiver(window)
+        (x, y, width, height) = config.get_window_geometry()
+        window.setGeometry(x, y, width, height)
+        window.show()
 
-    _LOGGER.info(f"Astro Live Stacker version {VERSION} started")
+    _LOGGER.info(f"Astro Live Stacker version {VERSION} started in {startup.elapsed_in_milli} ms.")
 
     app_return_code = app.exec()
     _LOGGER.info(f"Astro Live Stacker terminated with return code = {app_return_code}")

--- a/src/als/als.py
+++ b/src/als/als.py
@@ -778,7 +778,6 @@ class MainWindow(QMainWindow):
         self.file_watcher.observer.stop()
         self.file_watcher.terminate()
         self.image_ref_save.status = "stop"
-        self.image_ref_save.stack_image = None
         self._ui.cbAlign.setEnabled(True)
         self._ui.cmMode.setEnabled(True)
         self._ui.pbStop.setEnabled(False)

--- a/src/als/als.py
+++ b/src/als/als.py
@@ -726,8 +726,6 @@ class MainWindow(QMainWindow):
         # activate pause button
         self._ui.pbPause.setEnabled(True)
 
-        self._ui.action_prefs.setEnabled(False)
-
         _LOGGER.info(f"Work folder : '{config.get_work_folder_path()}'")
         _LOGGER.info(f"Scan folder : '{config.get_scan_folder_path()}'")
 
@@ -744,12 +742,13 @@ class MainWindow(QMainWindow):
         self._ui.log.scrollToBottom()
 
     @log
-    def update_store_display(self):
+    def update_according_to_app_state(self):
         """
         Updates all displays and controls depending on DataStore held data
         """
         messages = list()
 
+        # update statusBar according to status of folder scanner and web server
         messages.append(f"Scanning '{config.get_scan_folder_path()}'" if model.STORE.scan_in_progress else "Scanner : idle")
 
         if model.STORE.web_server_is_running:
@@ -758,6 +757,9 @@ class MainWindow(QMainWindow):
             messages.append("Web server : idle")
 
         self._ui.statusBar.showMessage('   -   '.join(messages))
+
+        # update preferences accessibility according to scanner and webserver status
+        self._ui.action_prefs.setEnabled(not STORE.web_server_is_running and not STORE.scan_in_progress)
 
     @log
     def _setup_work_folder(self):
@@ -785,7 +787,6 @@ class MainWindow(QMainWindow):
         self._ui.pbPlay.setEnabled(True)
         self._ui.pbReset.setEnabled(True)
         self._ui.pbPause.setEnabled(False)
-        self._ui.action_prefs.setEnabled(not self._ui.cbWww.isChecked())
         _LOGGER.info("Stop")
         model.STORE.scan_in_progress = False
 
@@ -896,7 +897,6 @@ class MainWindow(QMainWindow):
                 log_function = _LOGGER.info
 
             log_function(f"Web server started. Reachable at http://{ip_address}:{port_number}")
-            self._ui.action_prefs.setEnabled(False)
             model.STORE.web_server_is_running = True
         except OSError:
             title = "Could not start web server"
@@ -916,7 +916,6 @@ class MainWindow(QMainWindow):
             self.thread = None
             _LOGGER.info("Web server stopped")
             model.STORE.web_server_is_running = False
-            self._ui.action_prefs.setEnabled(self._ui.pbPlay.isEnabled())
 
     @staticmethod
     @log

--- a/src/als/code_utilities.py
+++ b/src/als/code_utilities.py
@@ -38,3 +38,13 @@ def log(func):
                      (end_time - start_time) * 1000)
         return result
     return wrapped
+
+
+class Timer:
+    def __enter__(self):
+        self.start = time()
+        return self
+
+    def __exit__(self, *args):
+        self.end = time()
+        self.elapsed_in_milli = "%0.3f" % ((self.end - self.start) * 1000)

--- a/src/als/code_utilities.py
+++ b/src/als/code_utilities.py
@@ -41,10 +41,32 @@ def log(func):
 
 
 class Timer:
+    """
+    A context manager, timing any portion of code it encloses.
+
+    Basic usage :
+
+    .. code-block:: python
+
+        with Timer() as t:
+
+            # your code here
+            # it can be many lines
+            pass
+
+        _LOGGER.info(f"code ran in {t.elapsed_in_milli} ms.")
+
+    The context manager exposes 2 attributes :
+
+        - elapsed_in_milli (float) = elapsed time
+        - elapsed_in_milli_as_str (str) = string representation of elapsed time with only 3 decimal positions
+
+    """
     def __enter__(self):
         self.start = time()
         return self
 
     def __exit__(self, *args):
         self.end = time()
-        self.elapsed_in_milli = "%0.3f" % ((self.end - self.start) * 1000)
+        self.elapsed_in_milli = (self.end - self.start) * 1000
+        self.elapsed_in_milli_as_str = "%0.3f" % self.elapsed_in_milli

--- a/src/als/config.py
+++ b/src/als/config.py
@@ -275,7 +275,8 @@ except ParsingError as parsing_error:
 
 # init logging system
 logging.basicConfig(level=_LOG_LEVELS[_get(_LOG_LEVEL)],
-                    format='%(asctime)s - %(levelname)s - %(name)s - %(message)s',
+                    format='%(asctime)-15s %(processName)s:%(process)d/%(threadName)-12s '
+                           '%(name)-15s %(levelname)-8s %(message)s',
                     stream=sys.stdout)
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/als/config.py
+++ b/src/als/config.py
@@ -32,6 +32,7 @@ _WORK_FOLDER_PATH = "work_folder_path"
 _LOG_LEVEL = "log_level"
 _WWW_SERVER_PORT = "www_server_port"
 _WINDOW_GEOMETRY = "window_geometry"
+_IMAGE_SAVE_FORMAT = "image_save_format"
 
 # keys used to describe logging level
 _LOG_LEVEL_DEBUG = "DEBUG"
@@ -39,6 +40,12 @@ _LOG_LEVEL_INFO = "INFO"
 _LOG_LEVEL_WARNING = "WARNING"
 _LOG_LEVEL_ERROR = "ERROR"
 _LOG_LEVEL_CRITICAL = "CRITICAL"
+
+# keys used to describe file save formats
+IMAGE_SAVE_TIFF = "tiff"
+IMAGE_SAVE_PNG = "png"
+IMAGE_SAVE_JPEG = "jpg"
+IMAGE_SAVE_FIT = "fit"
 
 # store of matches between human readable log levels and logging module constants
 _LOG_LEVELS = {
@@ -53,13 +60,48 @@ _LOG_LEVELS = {
 _DEFAULTS = {
     _SCAN_FOLDER_PATH:    os.path.expanduser("~/als/scan"),
     _WORK_FOLDER_PATH:    os.path.expanduser("~/als/work"),
-    _LOG_LEVEL:           "INFO",
+    _LOG_LEVEL:           _LOG_LEVEL_INFO,
     _WWW_SERVER_PORT:     "8000",
-    _WINDOW_GEOMETRY: "50,100,1024,800"
+    _WINDOW_GEOMETRY:     "50,100,1024,800",
+    _IMAGE_SAVE_FORMAT:   IMAGE_SAVE_JPEG,
 }
 _MAIN_SECTION_NAME = "main"
 
+# application constants
+STACKED_IMAGE_FILE_NAME_BASE = "stack_image"
+WEB_SERVED_IMAGE_FILE_NAME_BASE = "web_image"
+
 _CONFIG_PARSER = ConfigParser()
+
+
+def get_image_save_format():
+    """
+    Retrieves the configured image save format.
+
+    :return: format code. Can be any value from :
+
+      - IMAGE_SAVE_TIFF
+      - IMAGE_SAVE_PNG
+      - IMAGE_SAVE_JPEG
+
+    :rtype: str
+    """
+    return _get(_IMAGE_SAVE_FORMAT)
+
+
+def set_image_save_format(save_format):
+    """
+    Sets image save format.
+
+    :param save_format: format code. Can be any value from :
+
+      - IMAGE_SAVE_TIFF
+      - IMAGE_SAVE_PNG
+      - IMAGE_SAVE_JPEG
+
+    :type save_format: str
+    """
+    _set(_IMAGE_SAVE_FORMAT, save_format)
 
 
 def is_debug_log_on():

--- a/src/als/io/__init__.py
+++ b/src/als/io/__init__.py
@@ -1,0 +1,3 @@
+"""
+Everything related to I/O in ALS
+"""

--- a/src/als/io/output.py
+++ b/src/als/io/output.py
@@ -1,0 +1,270 @@
+"""
+Everything we need to perform outputs from ALS
+
+For now, we only save some images to disk, but who knows...
+"""
+import logging
+from queue import Queue
+
+import cv2
+from PyQt5.QtCore import QThread, pyqtSignal
+
+from astropy.io import fits
+
+from als import config
+from als.code_utilities import log
+
+_LOGGER = logging.getLogger(__name__)
+
+# queue to which are posted all image save commands
+_IMAGE_SAVE_QUEUE = Queue()
+
+
+class ImageSaveCommand:
+    """
+    Represents an image save command.
+
+    It encapsulated the image itself, the filename to save to and the target folder
+    """
+
+    @log
+    def __init__(self, image, target_path):
+        """
+        Creates a new ImageSaveCommand.
+
+        :param image: the image to save
+        :type image: numpy.Array
+
+        :param target_path: absolute path of the file to save image to
+        :type target_path: str
+        """
+        self._image = image
+        self._target_path = target_path
+
+    @log
+    def get_image(self):
+        """
+        Retrieves image data.
+
+        :return: the image data
+        :rtype: numpy.Array
+        """
+        return self._image
+
+    @log
+    def get_target_path(self):
+        """
+        Retrieves target path.
+
+        :return: absolute path of the file to save image to
+        :rtype: str
+        """
+        return self._target_path
+
+
+class ImageSaver(QThread):
+    """
+    Saves images according to commands posted to IMAGE_SAVE_QUEUE in its own thread
+
+    """
+
+    save_successful_signal = pyqtSignal(str)
+    save_fail_signal = pyqtSignal(str)
+
+    @log
+    def __init__(self):
+        super().__init__()
+        self._stop_asked = False
+
+    @log
+    def run(self):
+        """
+        Performs usual duty : Saving images to disk
+        """
+        # we keep polling the queue in 2 cases :
+        #
+        # - we have not been asked to stop, regardless of queue content
+        # OR
+        # - we have been asked to stop, and queue is not empty yet
+        while not self._stop_asked or not _IMAGE_SAVE_QUEUE.empty():
+            if not _IMAGE_SAVE_QUEUE.empty():
+                image_save_command = _IMAGE_SAVE_QUEUE.get_nowait()
+                self._save_image(image_save_command)
+            self.msleep(100)
+
+    @log
+    def stop(self):
+        """
+        Sets a flag that will interrupt the main loop in run()
+        """
+        _LOGGER.info("Stopping image saver")
+        queue_size = _IMAGE_SAVE_QUEUE.qsize()
+        if queue_size > 0:
+            _LOGGER.warning(f"There are still {queue_size} images waiting to be saved. Saving them all...")
+        self._stop_asked = True
+
+    @log
+    def _save_image(self, command):
+        """
+        Saves image to work folder
+
+        :param command: the image save command
+        :type command: ImageSaveCommand
+        """
+
+        target_path = command.get_target_path()
+
+        if target_path.endswith(config.IMAGE_SAVE_TIFF):
+            save_successful, details = ImageSaver._save_image_as_tiff(command.get_image(), target_path)
+
+        elif target_path.endswith(config.IMAGE_SAVE_PNG):
+            save_successful, details = ImageSaver._save_image_as_png(command.get_image(), target_path)
+
+        elif target_path.endswith(config.IMAGE_SAVE_JPEG):
+            save_successful, details = ImageSaver._save_image_as_jpg(command.get_image(), target_path)
+
+        elif target_path.endswith(config.IMAGE_SAVE_FIT):
+            save_successful, details = ImageSaver._save_image_as_fit(command.get_image(), target_path)
+
+        else:
+            # Unsupported format in config file. Should never happen
+            save_successful, details = False, f"Unsupported File format for {target_path}"
+
+        if save_successful:
+            message = f"Successful image save : {target_path}"
+            _LOGGER.info(message)
+            self.save_successful_signal.emit(message)
+
+        else:
+            message = f"ERROR, Failed to save image {target_path}. "
+            if details.strip():
+                message += details
+            _LOGGER.error(message)
+            self.save_fail_signal.emit(message)
+
+    @staticmethod
+    @log
+    def _save_image_as_tiff(image, target_path):
+        """
+        Saves image as tiff.
+
+        :param image: the image to save
+        :type image: numpy.Array
+
+        :param target_path: the absolute path of the image file to save to
+        :type target_path: str
+
+        :return: a tuple with 2 values :
+
+          - True if save succeeded, False otherwise
+          - Details on cause of save failure, if occurs
+
+        As we are using cv2.imwrite, we won't get any details on failures
+        """
+
+        return cv2.imwrite(target_path, image), ""
+
+    @staticmethod
+    @log
+    def _save_image_as_png(image, target_path):
+        """
+        Saves image as png.
+
+        :param image: the image to save
+        :type image: numpy.Array
+
+        :param target_path: the absolute path of the image file to save to
+        :type target_path: str
+
+        :return: a tuple with 2 values :
+
+          - True if save succeeded, False otherwise
+          - Details on cause of save failure, if occurs
+
+        As we are using cv2.imwrite, we won't get any details on failures
+        """
+
+        return cv2.imwrite(target_path,
+                           image,
+                           [cv2.IMWRITE_PNG_COMPRESSION, 9]), ""
+
+    @staticmethod
+    @log
+    def _save_image_as_jpg(image, target_path):
+        """
+        Saves image as jpg.
+
+        :param image: the image to save
+        :type image: numpy.Array
+
+        :param target_path: the absolute path of the image file to save to
+        :type target_path: str
+
+        :return: a tuple with 2 values :
+
+          - True if save succeeded, False otherwise
+          - Details on cause of save failure, if occurs
+
+        As we are using cv2.imwrite, we won't get any details on failures
+        """
+
+        image_to_save = image
+        if image_to_save.dtype == "uint16":
+            bit_depth = 16
+        else:
+            bit_depth = 8
+
+        if bit_depth > 8:
+            image_to_save = (image_to_save / (((2 ** bit_depth) - 1) / ((2 ** 8) - 1))).astype('uint8')
+
+        return cv2.imwrite(target_path,
+                           image_to_save,
+                           [int(cv2.IMWRITE_JPEG_QUALITY), 90]), ''
+
+    @staticmethod
+    @log
+    def _save_image_as_fit(image, target_path):
+        """
+        Saves image as fit.
+
+        :param image: the image to save
+        :type image: numpy.Array
+
+        :param target_path: the absolute path of the image file to save to
+        :type target_path: str
+
+        :return: a tuple with 2 values :
+
+          - True if save succeeded, False otherwise
+          - Details on cause of save failure, if occurs
+        """
+
+        hdu = fits.PrimaryHDU(data=image)
+
+        try:
+            hdu.writeto(target_path)
+            return True, ''
+
+        except OSError as os_error:
+            return False, str(os_error)
+
+
+@log
+def save_image(image_data, image_save_format, target_folder, file_name_base):
+    """
+    Saves an image to disk.
+
+    :param image_data: the image data
+    :type image_data: numpy.Array
+
+    :param image_save_format: image file format specifier
+    :type image_save_format: str
+
+    :param target_folder: path to target folder
+    :type target_folder: str
+
+    :param file_name_base: filename base (without extension)
+    :type file_name_base: str
+    """
+    target_path = target_folder + "/" + file_name_base + '.' + image_save_format
+    _IMAGE_SAVE_QUEUE.put(ImageSaveCommand(image_data, target_path))

--- a/src/als/model.py
+++ b/src/als/model.py
@@ -88,7 +88,7 @@ class DataStore:
         Tells all registered observers to update their display
         """
         for observer in self._observers:
-            observer.update_store_display()
+            observer.update_according_to_app_state()
 
 
 STORE = DataStore()

--- a/src/als/preprocess.py
+++ b/src/als/preprocess.py
@@ -164,7 +164,7 @@ def scnr(rgb_image, im_limit, rgb_type="RGB", scnr_type="ne_m", amount=0.5):
 
 
 @log
-def post_process_image(stack_image, log_ui, mode="rgb", scnr_on=False,
+def post_process_image(stack_image, mode="rgb", scnr_on=False,
                        wavelets_on=False, wavelets_type='deep sky',
                        wavelets_use_luminance=False, param=[]):
     """
@@ -182,13 +182,13 @@ def post_process_image(stack_image, log_ui, mode="rgb", scnr_on=False,
 
     # change action for mode :
     if mode == "rgb":
-        log_ui.append(_("Save New Image in RGB..."))
+        _LOGGER.info(_("Save New Image in RGB..."))
         # convert classic classic order to cv2 order
         new_stack_image = np.rollaxis(stack_image, 0, 3)
         # convert RGB color order to BGR
         new_stack_image = cv2.cvtColor(new_stack_image, cv2.COLOR_RGB2BGR)
     elif mode == "gray":
-        log_ui.append(_("Save New Image in B&W..."))
+        _LOGGER.info(_("Save New Image in B&W..."))
         new_stack_image = stack_image
 
     # read image number type
@@ -199,23 +199,23 @@ def post_process_image(stack_image, log_ui, mode="rgb", scnr_on=False,
             or param[5] != 1 or param[6] != 1 or param[8] != 50 or any([v != 1 for _, v in param[9].items()]):
 
         # print param value for post process
-        log_ui.append(_("Post-Process New Image..."))
-        log_ui.append(_("correct display image"))
-        log_ui.append(_("contrast value :") + " %f" % param[0])
-        log_ui.append(_("brightness value :") + "%f" % param[1])
-        log_ui.append(_("pente : ") + "%f" % (1. / ((param[3] - param[2]) / limit)))
+        _LOGGER.info(_("Post-Process New Image..."))
+        _LOGGER.info(_("correct display image"))
+        _LOGGER.info(_("contrast value :") + " %f" % param[0])
+        _LOGGER.info(_("brightness value :") + "%f" % param[1])
+        _LOGGER.info(_("pente : ") + "%f" % (1. / ((param[3] - param[2]) / limit)))
 
         # need convert to float32 for excess value
         new_stack_image = np.float32(new_stack_image)
 
         if scnr_on:
-            log_ui.append(_("apply SCNR"))
-            log_ui.append(_("SCNR type") + "%s" % param[7])
+            _LOGGER.info(_("apply SCNR"))
+            _LOGGER.info(_("SCNR type") + "%s" % param[7])
             new_stack_image = scnr(new_stack_image, limit, rgb_type="BGR", scnr_type=param[7], amount=param[8])
 
         if wavelets_on:
-            log_ui.append("apply Wavelets")
-            log_ui.append("Wavelets parameters {}".format(param[9]))
+            _LOGGER.info("apply Wavelets")
+            _LOGGER.info("Wavelets parameters {}".format(param[9]))
             new_stack_image = wavelets(new_stack_image,
                                        wavelets_type=wavelets_type,
                                        wavelets_use_luminance=wavelets_use_luminance,
@@ -226,9 +226,9 @@ def post_process_image(stack_image, log_ui, mode="rgb", scnr_on=False,
             if mode == "rgb":
                 # invert Red and Blue for cv2
                 # print RGB contrast value
-                log_ui.append(_("R contrast value : ") + "%f" % param[4])
-                log_ui.append(_("G contrast value : ") + "%f" % param[5])
-                log_ui.append(_("B contrast value : ") + "%f" % param[6])
+                _LOGGER.info(_("R contrast value : ") + "%f" % param[4])
+                _LOGGER.info(_("G contrast value : ") + "%f" % param[5])
+                _LOGGER.info(_("B contrast value : ") + "%f" % param[6])
 
                 # multiply by RGB factor
                 new_stack_image[:, :, 0] = new_stack_image[:, :, 0] * param[6]

--- a/src/als/preprocess.py
+++ b/src/als/preprocess.py
@@ -18,22 +18,15 @@ Provides image preprocessing features
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-# Numerical stuff
 import logging
 
 import cv2
-# Wavelet stuff
 import dtcwt
 import numpy as np
 from pywi.processing.transform import starlet
-
-# Local stuff
 from als import stack as stk
 from als.code_utilities import log
 
-NAME_OF_TIFF_IMAGE = "stack_image.tiff"
-NAME_OF_JPEG_IMAGE = "stack_image.jpg"
-NAME_OF_PNG_IMAGE = "stack_image.png"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -171,20 +164,18 @@ def scnr(rgb_image, im_limit, rgb_type="RGB", scnr_type="ne_m", amount=0.5):
 
 
 @log
-def save_tiff(work_path, stack_image, log_ui, mode="rgb", scnr_on=False,
-              wavelets_on=False, wavelets_type='deep sky',
-              wavelets_use_luminance=False, param=[], image_type="tiff"):
+def post_process_image(stack_image, log_ui, mode="rgb", scnr_on=False,
+                       wavelets_on=False, wavelets_type='deep sky',
+                       wavelets_use_luminance=False, param=[]):
     """
     Fonction for create print image and post process this image
 
-    :param work_path: string, path for work folder
     :param stack_image: np.array(uintX), Image, 3xMxN or MxN
     :param log_ui: QT log for print text in QT GUI
     :param mode: image mode ("rgb" or "gray")
     :param scnr_on: bool, activate scnr correction
     :param wavelets_on: bool, activate wavelet filtering
     :param param: post process param
-    :param image_type: "tiff", "no" and "jpeg"
     :return: no return
 
     """
@@ -267,33 +258,4 @@ def save_tiff(work_path, stack_image, log_ui, mode="rgb", scnr_on=False,
         elif im_type == "uint8":
             new_stack_image = np.uint8(new_stack_image)
 
-    # use cv2 fonction for save print image in tiff format
-    if image_type == "tiff":
-        cv2.imwrite(work_path + "/" + NAME_OF_TIFF_IMAGE, new_stack_image)
-        _LOGGER.info(_("TIFF image create :") + "%s" % work_path + "/" + NAME_OF_TIFF_IMAGE)
-        new_stack_image = cv2.cvtColor(new_stack_image, cv2.COLOR_BGR2RGB)
-
-    elif image_type == "png":
-        print(new_stack_image.dtype)
-        cv2.imwrite(work_path + "/" + NAME_OF_PNG_IMAGE, new_stack_image, [cv2.IMWRITE_PNG_COMPRESSION, 9])
-        _LOGGER.info(_("PNG image create :") + "%s" % work_path + "/" + NAME_OF_PNG_IMAGE)
-        new_stack_image = cv2.cvtColor(new_stack_image, cv2.COLOR_BGR2RGB)
-
-    elif image_type == "jpeg":
-        # limitate to 8bit
-        image_to_save = new_stack_image
-        if image_to_save.dtype == "uint16":
-            bit_depth = 16
-        else:
-            bit_depth = 8
-
-        if bit_depth > 8:
-            image_to_save = (image_to_save / (((2**bit_depth)-1) / ((2**8)-1))).astype('uint8')
-
-        cv2.imwrite(work_path + "/" + NAME_OF_JPEG_IMAGE, image_to_save, [int(cv2.IMWRITE_JPEG_QUALITY), 90])
-        _LOGGER.info(_("JPEG image create :") + "%s" % work_path + "/" + NAME_OF_JPEG_IMAGE)
-        new_stack_image = cv2.cvtColor(new_stack_image, cv2.COLOR_BGR2RGB)
-    elif image_type == "no":
-        _LOGGER.info(_("No image create, als use RAM"))
-        new_stack_image = cv2.cvtColor(new_stack_image, cv2.COLOR_BGR2RGB)
     return new_stack_image

--- a/src/als/ui/als_ui.ui
+++ b/src/als/ui/als_ui.ui
@@ -35,7 +35,7 @@
          <string/>
         </property>
         <property name="pixmap">
-         <pixmap>:/icons/dslr-camera.svg</pixmap>
+         <pixmap resource="../../resources/resource.qrc">:/icons/dslr-camera.svg</pixmap>
         </property>
         <property name="scaledContents">
          <bool>false</bool>
@@ -1275,6 +1275,14 @@
          <width>65535</width>
          <height>65535</height>
         </size>
+       </property>
+       <property name="font">
+        <font>
+         <family>Courier 10 Pitch</family>
+         <pointsize>9</pointsize>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
        </property>
       </widget>
      </item>

--- a/src/als/ui/als_ui.ui
+++ b/src/als/ui/als_ui.ui
@@ -1258,31 +1258,37 @@
     <string>Session log</string>
    </property>
    <attribute name="dockWidgetArea">
-    <number>4</number>
+    <number>8</number>
    </attribute>
    <widget class="QWidget" name="dockWidgetContents_2">
     <layout class="QVBoxLayout" name="verticalLayout_14">
      <item>
-      <widget class="QTextBrowser" name="log">
-       <property name="minimumSize">
-        <size>
-         <width>300</width>
-         <height>80</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>65535</width>
-         <height>65535</height>
-        </size>
-       </property>
+      <widget class="QListWidget" name="log">
        <property name="font">
         <font>
          <family>Courier 10 Pitch</family>
-         <pointsize>9</pointsize>
-         <weight>50</weight>
-         <bold>false</bold>
         </font>
+       </property>
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="showDropIndicator" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="alternatingRowColors">
+        <bool>false</bool>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::NoSelection</enum>
+       </property>
+       <property name="textElideMode">
+        <enum>Qt::ElideNone</enum>
+       </property>
+       <property name="isWrapping" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/als/ui/dialogs.py
+++ b/src/als/ui/dialogs.py
@@ -30,6 +30,15 @@ class PreferencesDialog(QDialog):
         self._ui.ln_web_server_port.setText(str(config.get_www_server_port_number()))
         self._ui.chk_debug_logs.setChecked(config.is_debug_log_on())
 
+        config_to_image_save_type_mapping = {
+
+            config.IMAGE_SAVE_JPEG: self._ui.radioSaveJpeg,
+            config.IMAGE_SAVE_PNG:  self._ui.radioSavePng,
+            config.IMAGE_SAVE_TIFF: self._ui.radioSaveTiff
+        }
+
+        config_to_image_save_type_mapping[config.get_image_save_format()].setChecked(True)
+
     # FIXME : using @log on this causes
     # TypeError: accept() takes 1 positional argument but 2 were given
     def accept(self):
@@ -50,6 +59,19 @@ class PreferencesDialog(QDialog):
             return
 
         config.set_debug_log(self._ui.chk_debug_logs.isChecked())
+
+        image_save_type_to_config_mapping = {
+
+            self._ui.radioSaveJpeg: config.IMAGE_SAVE_JPEG,
+            self._ui.radioSavePng:  config.IMAGE_SAVE_PNG,
+            self._ui.radioSaveTiff: config.IMAGE_SAVE_TIFF
+        }
+
+        for radio_button, image_save_type in image_save_type_to_config_mapping.items():
+            if radio_button.isChecked():
+                config.set_image_save_format(image_save_type)
+                break
+
         config.save()
 
         super().accept()

--- a/src/als/ui/prefs_ui.ui
+++ b/src/als/ui/prefs_ui.ui
@@ -6,164 +6,190 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>568</width>
-    <height>296</height>
+    <width>566</width>
+    <height>369</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>ALS preferences</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4">
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>Pathes</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Pathes</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QLabel" name="lbl_scan_folder">
-            <property name="text">
-             <string>&amp;Scan folder :</string>
-            </property>
-            <property name="buddy">
-             <cstring>btn_browse_scan</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="ln_scan_folder_path">
-            <property name="minimumSize">
-             <size>
-              <width>350</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="btn_browse_scan">
-            <property name="text">
-             <string>Change...</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QLabel" name="lbl_work_folder">
-            <property name="text">
-             <string>&amp;Work folder :</string>
-            </property>
-            <property name="buddy">
-             <cstring>btn_browse_work</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="ln_work_folder_path">
-            <property name="minimumSize">
-             <size>
-              <width>350</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="btn_browse_work">
-            <property name="text">
-             <string>Change...</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_2">
-       <property name="title">
-        <string>Web server</string>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <item>
-           <widget class="QLabel" name="lbl_server_port">
-            <property name="text">
-             <string>Server &amp;port number (between 1024 and 65535) :</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::AutoText</enum>
-            </property>
-            <property name="buddy">
-             <cstring>ln_web_server_port</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="ln_web_server_port">
-            <property name="maximumSize">
-             <size>
-              <width>75</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="inputMask">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_3">
-       <property name="title">
-        <string>Misc</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <item>
-         <widget class="QCheckBox" name="chk_debug_logs">
+         <widget class="QLabel" name="lbl_scan_folder">
           <property name="text">
-           <string>&amp;Debug logs (requires application restart)</string>
+           <string>&amp;Scan folder :</string>
+          </property>
+          <property name="buddy">
+           <cstring>btn_browse_scan</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="ln_scan_folder_path">
+          <property name="minimumSize">
+           <size>
+            <width>350</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btn_browse_scan">
+          <property name="text">
+           <string>Change...</string>
           </property>
          </widget>
         </item>
        </layout>
-      </widget>
-     </item>
-    </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="lbl_work_folder">
+          <property name="text">
+           <string>&amp;Work folder :</string>
+          </property>
+          <property name="buddy">
+           <cstring>btn_browse_work</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="ln_work_folder_path">
+          <property name="minimumSize">
+           <size>
+            <width>350</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btn_browse_work">
+          <property name="text">
+           <string>Change...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
-   <item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>File saving format</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_6">
+      <item>
+       <widget class="QRadioButton" name="radioSaveTiff">
+        <property name="text">
+         <string>&amp;Tiff</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioSavePng">
+        <property name="text">
+         <string>Pn&amp;g</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioSaveJpeg">
+        <property name="text">
+         <string>&amp;Jpeg</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Web server</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="lbl_server_port">
+          <property name="text">
+           <string>Server &amp;port number (between 1024 and 65535) :</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::AutoText</enum>
+          </property>
+          <property name="buddy">
+           <cstring>ln_web_server_port</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="ln_web_server_port">
+          <property name="maximumSize">
+           <size>
+            <width>75</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="inputMask">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Misc</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QCheckBox" name="chk_debug_logs">
+        <property name="text">
+         <string>&amp;Debug logs (requires application restart)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="sizeConstraint">
       <enum>QLayout::SetDefaultConstraint</enum>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -26,7 +26,7 @@
 </head>
 <body bgcolor="#111111">
 <div id="image" class="imgbox">
-    <img class="center-fit" src="stack_image.png">
+    <img class="center-fit" src="web_image.jpg">
 </div>
 </body>
 </html>


### PR DESCRIPTION
This work makes ALS perform all image save actions in a separated thread

Image file format for save is now configurable. available choices are :
- tiff
- jpeg
- png

Images served by the builtin webserver are always saved as jpeg

Once this PR is merged, branch 'develop_jpeg' can be deleted

Fixes Issue #57