### PR TITLE
Add EXIF for jpeg images

### DIFF
--- a/ci/build_dist_windows.sh
+++ b/ci/build_dist_windows.sh
@@ -62,4 +62,4 @@ echo "Building package version: ${VERSION}"
 
 sed -e "s/##VERSION##/${VERSION}/g" -e "s/##VERCODE##/${VERCODE}/g" ci/file_version_info_template.txt > ci/file_version_info.txt
 
-pyinstaller -i src/resources/als_logo.ico -F -n als --windowed --version-file=ci/file_version_info.txt --add-data 'src/resources/qt.conf:.' src/als/main.py
+pyinstaller --hidden-import "pkg_resources.py2_warn" -i src/resources/als_logo.ico -F -n als --windowed --version-file=ci/file_version_info.txt --add-data 'src/resources/qt.conf:.' src/als/main.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ exifread
 llvmlite==0.32.1
 scipy==1.4.1
 matplotlib==3.2.1
-Pillow==7.1.2
+Pillow==9.5.0
 pandas==1.0.4
 importlib_metadata==1.6.1
 more_itertools==8.3.0

--- a/src/als/logic.py
+++ b/src/als/logic.py
@@ -699,6 +699,8 @@ class Controller:
             filename_base += '-' + get_timestamp().replace(' ', "-").replace(":", '-').replace('.', '-')
 
         image_to_save = image.clone(keep_ref_to_data=True)
+        image_to_save.total_exposure_time = DYNAMIC_DATA.total_exposure_time
+        image_to_save.stack_size = DYNAMIC_DATA.stack_size
         image_to_save.destination = dest_folder_path + "/" + filename_base + '.' + file_extension
         self._saver_queue.put(image_to_save)
 

--- a/src/als/model/base.py
+++ b/src/als/model/base.py
@@ -103,6 +103,8 @@ class Image:
         self._destination: str = "UNDEFINED"
         self._ticket = ""
         self._exposure_time: float = Image.UNDEF_EXP_TIME
+        self._total_exposure_time: float = Image.UNDEF_EXP_TIME
+        self._stack_size = 0
 
     @log
     def clone(self, keep_ref_to_data=False):
@@ -122,7 +124,25 @@ class Image:
         new_image.destination = self.destination
         new_image.ticket = self.ticket
         new_image.exposure_time = self.exposure_time
+        new_image.total_exposure_time = self.total_exposure_time
+        new_image.stack_size = self.stack_size
         return new_image
+
+    @property
+    def stack_size(self):
+        return self._stack_size
+
+    @stack_size.setter
+    def stack_size(self, value):
+        self._stack_size = value
+
+    @property
+    def total_exposure_time(self):
+        return self._total_exposure_time
+
+    @total_exposure_time.setter
+    def total_exposure_time(self, value):
+        self._total_exposure_time = value
 
     @property
     def exposure_time(self):


### PR DESCRIPTION
This PR adds EXIF data to JPEG output images containing the number of subs used to stack this image and the total integration time. It should also be possible to use the same technique to the TIFF and perhaps the PNG images as well, although I don't need this so I didn't do it.

It adds 4 EXIF fields :-

ImageDescription = json encoded data e.g. {"stack_size": 2, "total_exposure_time": 120.0}
CompositeImage = 2 <-- always 2, means "General Composite Image"
CompositeImageCount = <stack size> e.g. 2
ExposureTime = <total exposure time> e.g. 120

Once the image contains EXIF,  it becomes possible to extract using exif-js library. For example, this is what I use on my blog to show information about the live stack progress. 

const existingImage = document.getElementById('livestackimage');
existingImage.onload = function() {
      EXIF.getData(existingImage, function() {
          var imageDescription = EXIF.getTag(this, "ImageDescription");
          if (imageDescription) {
              imageJson = JSON.parse(imageDescription)
              var stacking_details = document.getElementById("stacking_details");
              stacking_details.innerHTML = `${imageJson.total_exposure_time}s total integration time from ${imageJson.stack_size} frames`
          }
      });
};
