### PR TITLE
Adjust weights for v0.7 and v1.0 documentation pages

### DIFF
--- a/website/content/en/docs/v0.7/_index.md
+++ b/website/content/en/docs/v0.7/_index.md
@@ -3,7 +3,7 @@ title: ALS v0.7 Documentation
 description: ALS v0.7 Documentation
 author: ALS Team
 lastmod: 2025-11-02T20:24:25Z
-weight: 10
+weight: 70010
 ---
 
 ALS is a livestacking application.

--- a/website/content/en/docs/v0.7/installation/_index.md
+++ b/website/content/en/docs/v0.7/installation/_index.md
@@ -3,7 +3,7 @@ title: Installation
 description: installation of ALS
 author: ALS Team
 lastmod: 2024-12-31T20:05:37Z
-weight: 200
+weight: 70200
 tags: ['install']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v0.7/installation/linux-install.md
+++ b/website/content/en/docs/v0.7/installation/linux-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Linux PC
 author: ALZ Team
 lastmod: 2025-10-24T09:46:04Z
 keywords: [ "installation", "linux", "astro live stacker", "guide" ]
-weight: 210
+weight: 70210
 tags: ['install', 'Linux', 'PC']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v0.7/installation/mac-arm-install.md
+++ b/website/content/en/docs/v0.7/installation/mac-arm-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Mac Apple Silicon
 author: ALZ Team
 lastmod: 2025-10-24T09:46:04Z
 keywords: ["installation", "mac", "m1", "m2", "astro live stacker", "guide"]
-weight: 240
+weight: 70240
 tags: ['install', 'Mac', 'Apple Silicon']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v0.7/installation/mac-intel-install.md
+++ b/website/content/en/docs/v0.7/installation/mac-intel-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Mac Intel
 author: ALZ Team
 lastmod: 2025-10-24T09:46:04Z
 keywords: ["installation", "mac", "intel", "astro live stacker", "guide"]
-weight: 240
+weight: 70240
 tags: ['install', 'Mac', 'Apple Intel']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v0.7/installation/raspberry-pi-install.md
+++ b/website/content/en/docs/v0.7/installation/raspberry-pi-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Raspberry Pi
 author: ALZ Team
 lastmod: 2025-10-24T09:46:04Z
 keywords: [ "installation", "raspberry pi", "linux", "astro live stacker", "guide" ]
-weight: 220
+weight: 70220
 tags: ['install', 'Linux', 'Raspberry Pi']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v0.7/installation/windows-install.md
+++ b/website/content/en/docs/v0.7/installation/windows-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Windows
 author: ALZ Team
 lastmod: 2025-10-24T09:46:04Z
 keywords: [ "ALS install", "windows", "astro live stacker", "guide" ]
-weight: 230
+weight: 70230
 tags: [ 'install', 'Windows', 'PC' ]
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v0.7/quickstart/_index.md
+++ b/website/content/en/docs/v0.7/quickstart/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "beginner's guide" ]
 tags: [ "linux", "scan folder", "session", "work folder"  ]
-weight: 280
+weight: 70280
 ---
 
 # Introduction

--- a/website/content/en/docs/v0.7/reference/_index.md
+++ b/website/content/en/docs/v0.7/reference/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "process"]
-weight: 340
+weight: 70340
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/_index.md
+++ b/website/content/en/docs/v0.7/reference/modules/_index.md
@@ -7,7 +7,7 @@ keywords: [ "ALS modules and processes" ]
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "module", "process" ]
-weight: 345
+weight: 70345
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/preprocess/_index.md
+++ b/website/content/en/docs/v0.7/reference/modules/preprocess/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "calibration"]
-weight: 352
+weight: 70352
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/preprocess/dark_remove.md
+++ b/website/content/en/docs/v0.7/reference/modules/preprocess/dark_remove.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["process", "dark", "calibration"]
-weight: 354
+weight: 70354
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/preprocess/debayer.md
+++ b/website/content/en/docs/v0.7/reference/modules/preprocess/debayer.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "debayer", "calibration" ]
-weight: 355
+weight: 70355
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/preprocess/hot_remove.md
+++ b/website/content/en/docs/v0.7/reference/modules/preprocess/hot_remove.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["process", "hot pixels", "calibration"]
-weight: 353
+weight: 70353
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/process/_index.md
+++ b/website/content/en/docs/v0.7/reference/modules/process/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module"]
-weight: 357
+weight: 70357
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/process/autostretch.md
+++ b/website/content/en/docs/v0.7/reference/modules/process/autostretch.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "stretch", "image adjustment" ]
-weight: 358
+weight: 70358
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/process/levels.md
+++ b/website/content/en/docs/v0.7/reference/modules/process/levels.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "levels", "image adjustment" ]
-weight: 359
+weight: 70359
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/process/rgb-balance.md
+++ b/website/content/en/docs/v0.7/reference/modules/process/rgb-balance.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "color balance", "image adjustment" ]
-weight: 360
+weight: 70360
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/save.md
+++ b/website/content/en/docs/v0.7/reference/modules/save.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "output", "web folder", "work folder", "save"]
-weight: 361
+weight: 70361
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/scanner.md
+++ b/website/content/en/docs/v0.7/reference/modules/scanner.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "input", "scan folder", "scanner", "profile"]
-weight: 350
+weight: 70350
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/server.md
+++ b/website/content/en/docs/v0.7/reference/modules/server.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "server", "utility", "web", "stream"]
-weight: 362
+weight: 70362
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/reference/modules/stack.md
+++ b/website/content/en/docs/v0.7/reference/modules/stack.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "module", "process", "stack", "threshold" ]
-weight: 356
+weight: 70356
 ---
 
 # Overview

--- a/website/content/en/docs/v0.7/releasenotes/_index.md
+++ b/website/content/en/docs/v0.7/releasenotes/_index.md
@@ -5,7 +5,7 @@ author: ALS Team
 lastmod: 2025-10-27T10:13:07Z
 keywords: [ 'ALS Release Notes' ]
 tags: [ ]
-weight: 550
+weight: 70550
 ---
 
 ## Version 0.7 {#0.7}

--- a/website/content/en/docs/v0.7/userguide/_index.md
+++ b/website/content/en/docs/v0.7/userguide/_index.md
@@ -8,7 +8,7 @@ keywords: [ "ALS user guide" ]
 draft: false
 type: "docs"
 tags: [ "glossary" , "typography" ]
-weight: 300
+weight: 70300
 ---
 
 **Let yourself be guided!** We will show you everything you need to know about ALS for smooth and optimal use, tailored

--- a/website/content/en/docs/v0.7/userguide/concepts.md
+++ b/website/content/en/docs/v0.7/userguide/concepts.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "beginner's guide" ]
 tags: [ "module", "stack", "process", "session","output", "scan folder", "work folder", "web folder", "server", "scanner", "save", "calibration", "profile" ]
-weight: 315
+weight: 70315
 ---
 
 # Introduction

--- a/website/content/en/docs/v0.7/userguide/preferences/_index.md
+++ b/website/content/en/docs/v0.7/userguide/preferences/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: [ ]
-weight: 330
+weight: 70330
 ---
 
 The vast majority of the application configuration is done through the **Preferences** window.

--- a/website/content/en/docs/v0.7/userguide/preferences/general/_index.md
+++ b/website/content/en/docs/v0.7/userguide/preferences/general/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration", "troubleshooting"]
 tags: [ "scan folder", "memory", "profile", "language" ]
-weight: 331
+weight: 70331
 ---
 
 The most critical ALS settings are presented in the `General` tab.

--- a/website/content/en/docs/v0.7/userguide/preferences/output/_index.md
+++ b/website/content/en/docs/v0.7/userguide/preferences/output/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: ["output", "server", "web folder", "work folder", "save"]
-weight: 333
+weight: 70333
 ---
 
 The settings governing ALS outputs are presented in the `Output` tab.

--- a/website/content/en/docs/v0.7/userguide/preferences/processing/_index.md
+++ b/website/content/en/docs/v0.7/userguide/preferences/processing/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: ["process", "debayer", "dark", "hot pixels", "calibration"]
-weight: 332
+weight: 70332
 ---
 
 The ALS processing settings are presented in the Preferences page `Process` tab

--- a/website/content/en/docs/v0.7/userguide/session.md
+++ b/website/content/en/docs/v0.7/userguide/session.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "usage", "configuration" ]
 tags: [ "session", "server", "profile" ]
-weight: 317
+weight: 70317
 ---
 
 # 📘 Introduction

--- a/website/content/en/docs/v0.7/userguide/ui/_index.md
+++ b/website/content/en/docs/v0.7/userguide/ui/_index.md
@@ -8,7 +8,7 @@ keywords: ["ALS GUI", "ALS Interface"]
 type: "docs"
 categories: ["usage"]
 tags: ["interface", "panels"]
-weight: 320
+weight: 70320
 ---
 
 # Introduction

--- a/website/content/en/docs/v0.7/userguide/ui/controls/_index.md
+++ b/website/content/en/docs/v0.7/userguide/ui/controls/_index.md
@@ -7,7 +7,7 @@ keywords: [ "main controls of ALS" ]
 type: "docs"
 tags: [ "stack", "session", "server", "output", "threshold", "save", "issues", "panels" ]
 categories: ["usage", "configuration"]
-weight: 321
+weight: 70321
 ---
 
 # Introduction

--- a/website/content/en/docs/v0.7/userguide/ui/log/_index.md
+++ b/website/content/en/docs/v0.7/userguide/ui/log/_index.md
@@ -7,7 +7,7 @@ keywords: [ "session log", "follow", "errors", "log", "panels" ]
 type: "docs"
 tags: [ "log", "issues", "errors", "panels" ]
 categories: [ "usage", "troubleshooting" ]
-weight: 323
+weight: 70323
 ---
 
 # Introduction

--- a/website/content/en/docs/v0.7/userguide/ui/menu/_index.md
+++ b/website/content/en/docs/v0.7/userguide/ui/menu/_index.md
@@ -8,7 +8,7 @@ keywords: ["ALS Menu"]
 type: "docs"
 categories: ["usage"]
 tags: [ ]
-weight: 325
+weight: 70325
 ---
 
 ## File

--- a/website/content/en/docs/v0.7/userguide/ui/processing/_index.md
+++ b/website/content/en/docs/v0.7/userguide/ui/processing/_index.md
@@ -7,7 +7,7 @@ keywords: [ "ALS processing", "histogram", "auto stretch", "levels", "RGB balanc
 type: "docs"
 tags: [ "histogram", "stretch", "sliders", "processing", "panels" ]
 categories: [ "usage", "configuration" ]
-weight: 322
+weight: 70322
 ---
 
 # Introduction

--- a/website/content/en/docs/v0.7/userguide/ui/shortcuts.md
+++ b/website/content/en/docs/v0.7/userguide/ui/shortcuts.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "usage" ]
 tags: [ "" ]
-weight: 324
+weight: 70324
 ---
 
 <div class="row">

--- a/website/content/en/docs/v1.0/_index.md
+++ b/website/content/en/docs/v1.0/_index.md
@@ -3,7 +3,7 @@ title: ALS v1.0 Documentation
 description: ALS v1.0 Documentation
 author: ALS Team
 lastmod: 2025-11-02T20:24:25Z
-weight: 10
+weight: 100010
 ---
 
 ALS is a livestacking application.

--- a/website/content/en/docs/v1.0/installation/_index.md
+++ b/website/content/en/docs/v1.0/installation/_index.md
@@ -3,7 +3,7 @@ title: Installation
 description: installation of ALS
 author: ALS Team
 lastmod: 2025-11-02T19:02:51Z
-weight: 200
+weight: 100200
 tags: ['install']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v1.0/installation/linux-install.md
+++ b/website/content/en/docs/v1.0/installation/linux-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Linux PC
 author: ALZ Team
 lastmod: 2025-11-02T20:58:20Z
 keywords: [ "installation", "linux", "astro live stacker", "guide" ]
-weight: 210
+weight: 100210
 tags: ['install', 'Linux', 'PC']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v1.0/installation/mac-arm-install.md
+++ b/website/content/en/docs/v1.0/installation/mac-arm-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Mac Apple Silicon
 author: ALZ Team
 lastmod: 2025-11-02T20:58:20Z
 keywords: ["installation", "mac", "m1", "m2", "astro live stacker", "guide"]
-weight: 240
+weight: 100240
 tags: ['install', 'Mac', 'Apple Silicon']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v1.0/installation/mac-intel-install.md
+++ b/website/content/en/docs/v1.0/installation/mac-intel-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Mac Intel
 author: ALZ Team
 lastmod: 2025-11-02T20:58:20Z
 keywords: ["installation", "mac", "intel", "astro live stacker", "guide"]
-weight: 240
+weight: 100240
 tags: ['install', 'Mac', 'Apple Intel']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v1.0/installation/raspberry-pi-install.md
+++ b/website/content/en/docs/v1.0/installation/raspberry-pi-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Raspberry Pi
 author: ALZ Team
 lastmod: 2025-11-02T20:58:20Z
 keywords: [ "installation", "raspberry pi", "linux", "astro live stacker", "guide" ]
-weight: 220
+weight: 100220
 tags: ['install', 'Linux', 'Raspberry Pi']
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v1.0/installation/windows-install.md
+++ b/website/content/en/docs/v1.0/installation/windows-install.md
@@ -4,7 +4,7 @@ description: Installing ALS on Windows
 author: ALZ Team
 lastmod: 2025-11-02T20:58:20Z
 keywords: [ "ALS install", "windows", "astro live stacker", "guide" ]
-weight: 230
+weight: 100230
 tags: [ 'install', 'Windows', 'PC' ]
 categories : ['procedures']
 ---

--- a/website/content/en/docs/v1.0/quickstart/_index.md
+++ b/website/content/en/docs/v1.0/quickstart/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "beginner's guide" ]
 tags: [ "linux", "scan folder", "session", "work folder"  ]
-weight: 280
+weight: 100280
 ---
 
 # Introduction

--- a/website/content/en/docs/v1.0/reference/_index.md
+++ b/website/content/en/docs/v1.0/reference/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "process"]
-weight: 340
+weight: 100340
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/_index.md
+++ b/website/content/en/docs/v1.0/reference/modules/_index.md
@@ -7,7 +7,7 @@ keywords: [ "ALS modules and processes" ]
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "module", "process" ]
-weight: 345
+weight: 100345
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/preprocess/_index.md
+++ b/website/content/en/docs/v1.0/reference/modules/preprocess/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "calibration"]
-weight: 352
+weight: 100352
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/preprocess/dark_remove.md
+++ b/website/content/en/docs/v1.0/reference/modules/preprocess/dark_remove.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["process", "dark", "calibration"]
-weight: 354
+weight: 100354
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/preprocess/debayer.md
+++ b/website/content/en/docs/v1.0/reference/modules/preprocess/debayer.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "debayer", "calibration" ]
-weight: 355
+weight: 100355
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/preprocess/hot_remove.md
+++ b/website/content/en/docs/v1.0/reference/modules/preprocess/hot_remove.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["process", "hot pixels", "calibration"]
-weight: 353
+weight: 100353
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/process/_index.md
+++ b/website/content/en/docs/v1.0/reference/modules/process/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module"]
-weight: 357
+weight: 100357
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/process/autostretch.md
+++ b/website/content/en/docs/v1.0/reference/modules/process/autostretch.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "stretch", "image adjustment" ]
-weight: 358
+weight: 100358
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/process/levels.md
+++ b/website/content/en/docs/v1.0/reference/modules/process/levels.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "levels", "image adjustment" ]
-weight: 359
+weight: 100359
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/process/rgb-balance.md
+++ b/website/content/en/docs/v1.0/reference/modules/process/rgb-balance.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "color balance", "image adjustment" ]
-weight: 360
+weight: 100360
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/save.md
+++ b/website/content/en/docs/v1.0/reference/modules/save.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "output", "web folder", "work folder", "save"]
-weight: 361
+weight: 100361
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/scanner.md
+++ b/website/content/en/docs/v1.0/reference/modules/scanner.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "input", "scan folder", "scanner", "profile"]
-weight: 350
+weight: 100350
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/server.md
+++ b/website/content/en/docs/v1.0/reference/modules/server.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["detailed documentations"]
 tags: ["module", "server", "utility", "web", "stream"]
-weight: 362
+weight: 100362
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/stack.md
+++ b/website/content/en/docs/v1.0/reference/modules/stack.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "module", "process", "stack", "threshold" ]
-weight: 356
+weight: 100356
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/releasenotes/_index.md
+++ b/website/content/en/docs/v1.0/releasenotes/_index.md
@@ -5,7 +5,7 @@ author: ALS Team
 lastmod: 2025-11-02T19:02:51Z
 keywords: [ 'ALS Release Notes' ]
 tags: [ ]
-weight: 550
+weight: 100550
 ---
 
 ## Version 0.7 {#0.7}

--- a/website/content/en/docs/v1.0/userguide/_index.md
+++ b/website/content/en/docs/v1.0/userguide/_index.md
@@ -8,7 +8,7 @@ keywords: [ "ALS user guide" ]
 draft: false
 type: "docs"
 tags: [ "glossary" , "typography" ]
-weight: 300
+weight: 100300
 ---
 
 **Let yourself be guided!** We will show you everything you need to know about ALS for smooth and optimal use, tailored

--- a/website/content/en/docs/v1.0/userguide/concepts.md
+++ b/website/content/en/docs/v1.0/userguide/concepts.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "beginner's guide" ]
 tags: [ "module", "stack", "process", "session","output", "scan folder", "work folder", "web folder", "server", "scanner", "save", "calibration", "profile" ]
-weight: 315
+weight: 100315
 ---
 
 # Introduction

--- a/website/content/en/docs/v1.0/userguide/preferences/_index.md
+++ b/website/content/en/docs/v1.0/userguide/preferences/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: [ ]
-weight: 330
+weight: 100330
 ---
 
 The vast majority of the application configuration is done through the **Preferences** window.

--- a/website/content/en/docs/v1.0/userguide/preferences/general/_index.md
+++ b/website/content/en/docs/v1.0/userguide/preferences/general/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration", "troubleshooting"]
 tags: [ "scan folder", "memory", "profile", "language" ]
-weight: 331
+weight: 100331
 ---
 
 The most critical ALS settings are presented in the `General` tab.

--- a/website/content/en/docs/v1.0/userguide/preferences/output/_index.md
+++ b/website/content/en/docs/v1.0/userguide/preferences/output/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: ["output", "server", "web folder", "work folder", "save"]
-weight: 333
+weight: 100333
 ---
 
 The settings governing ALS outputs are presented in the `Output` tab.

--- a/website/content/en/docs/v1.0/userguide/preferences/processing/_index.md
+++ b/website/content/en/docs/v1.0/userguide/preferences/processing/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: ["process", "debayer", "dark", "hot pixels", "calibration"]
-weight: 332
+weight: 100332
 ---
 
 The ALS processing settings are presented in the Preferences page `Process` tab

--- a/website/content/en/docs/v1.0/userguide/session.md
+++ b/website/content/en/docs/v1.0/userguide/session.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "usage", "configuration" ]
 tags: [ "session", "server", "profile" ]
-weight: 317
+weight: 100317
 ---
 
 # 📘 Introduction

--- a/website/content/en/docs/v1.0/userguide/ui/_index.md
+++ b/website/content/en/docs/v1.0/userguide/ui/_index.md
@@ -8,7 +8,7 @@ keywords: ["ALS GUI", "ALS Interface"]
 type: "docs"
 categories: ["usage"]
 tags: ["interface", "panels"]
-weight: 320
+weight: 100320
 ---
 
 # Introduction

--- a/website/content/en/docs/v1.0/userguide/ui/controls/_index.md
+++ b/website/content/en/docs/v1.0/userguide/ui/controls/_index.md
@@ -7,7 +7,7 @@ keywords: [ "main controls of ALS" ]
 type: "docs"
 tags: [ "stack", "session", "server", "output", "threshold", "save", "issues", "panels" ]
 categories: ["usage", "configuration"]
-weight: 321
+weight: 100321
 ---
 
 # Introduction

--- a/website/content/en/docs/v1.0/userguide/ui/log/_index.md
+++ b/website/content/en/docs/v1.0/userguide/ui/log/_index.md
@@ -7,7 +7,7 @@ keywords: [ "session log", "follow", "errors", "log", "panels" ]
 type: "docs"
 tags: [ "log", "issues", "errors", "panels" ]
 categories: [ "usage", "troubleshooting" ]
-weight: 323
+weight: 100323
 ---
 
 # Introduction

--- a/website/content/en/docs/v1.0/userguide/ui/menu/_index.md
+++ b/website/content/en/docs/v1.0/userguide/ui/menu/_index.md
@@ -8,7 +8,7 @@ keywords: ["ALS Menu"]
 type: "docs"
 categories: ["usage"]
 tags: [ ]
-weight: 325
+weight: 100325
 ---
 
 ## File

--- a/website/content/en/docs/v1.0/userguide/ui/processing/_index.md
+++ b/website/content/en/docs/v1.0/userguide/ui/processing/_index.md
@@ -7,7 +7,7 @@ keywords: [ "ALS processing", "histogram", "auto stretch", "levels", "RGB balanc
 type: "docs"
 tags: [ "histogram", "stretch", "sliders", "processing", "panels" ]
 categories: [ "usage", "configuration" ]
-weight: 322
+weight: 100322
 ---
 
 # Introduction

--- a/website/content/en/docs/v1.0/userguide/ui/shortcuts.md
+++ b/website/content/en/docs/v1.0/userguide/ui/shortcuts.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "usage" ]
 tags: [ "" ]
-weight: 324
+weight: 100324
 ---
 
 <div class="row">

--- a/website/content/fr/docs/v0.7/_index.md
+++ b/website/content/fr/docs/v0.7/_index.md
@@ -3,7 +3,7 @@ title: Documentation ALS v0.7
 description: Documentation ALS v0.7
 author: ALZ Team
 lastmod: 2025-11-02T20:24:25Z
-weight: 10
+weight: 70010
 ---
 
 ALS est une application de livestacking.

--- a/website/content/fr/docs/v0.7/installation/_index.md
+++ b/website/content/fr/docs/v0.7/installation/_index.md
@@ -3,7 +3,7 @@ title: Installation
 description: installation d'ALS
 author: ALZ Team
 lastmod: 2024-12-31T20:05:37Z
-weight: 200
+weight: 70200
 Categories: ['procédures']
 ---
 

--- a/website/content/fr/docs/v0.7/installation/linux-install.md
+++ b/website/content/fr/docs/v0.7/installation/linux-install.md
@@ -4,7 +4,7 @@ description: Installation d'ALS sur PC Linux
 author: ALZ Team
 lastmod: 2025-10-24T09:46:04Z
 keywords: [ "installation", "linux", "astro live stacker", "guide" ]
-weight: 210
+weight: 70210
 Categories: ['procédures']
 tags: ['install', 'Linux', 'PC']
 ---

--- a/website/content/fr/docs/v0.7/installation/mac-arm-install.md
+++ b/website/content/fr/docs/v0.7/installation/mac-arm-install.md
@@ -5,7 +5,7 @@ author: ALZ Team
 
 lastmod: 2025-10-24T09:46:04Z
 keywords: ["installation", "mac", "m1", "m2", "astro live stacker", "guide"]
-weight: 240
+weight: 70240
 Categories: ['procédures']
 tags: ['install', 'Mac', 'Apple Silicon']
 ---

--- a/website/content/fr/docs/v0.7/installation/mac-intel-install.md
+++ b/website/content/fr/docs/v0.7/installation/mac-intel-install.md
@@ -5,7 +5,7 @@ author: ALZ Team
 
 lastmod: 2025-10-24T09:46:04Z
 keywords: ["installation", "mac", "intel", "astro live stacker", "guide"]
-weight: 240
+weight: 70240
 Categories: ['procédures']
 tags: ['install', 'Mac', 'Apple Intel']
 ---

--- a/website/content/fr/docs/v0.7/installation/raspberry-pi-install.md
+++ b/website/content/fr/docs/v0.7/installation/raspberry-pi-install.md
@@ -5,7 +5,7 @@ author: ALZ Team
 
 lastmod: 2025-10-24T09:46:04Z
 keywords: [ "installation", "raspberry pi", "linux", "astro live stacker", "guide" ]
-weight: 220
+weight: 70220
 Categories: ['procédures']
 tags: ['install', 'Linux', 'Raspberry Pi']
 ---

--- a/website/content/fr/docs/v0.7/installation/windows-install.md
+++ b/website/content/fr/docs/v0.7/installation/windows-install.md
@@ -4,7 +4,7 @@ description: Installation d'ALS sur PC Windows
 author: ALZ Team
 lastmod: 2025-10-24T09:46:04Z
 keywords: [ "installation ALS", "windows", "astro live stacker", "guide" ]
-weight: 230
+weight: 70230
 Categories: ['procédures']
 tags: [ 'install', 'Windows', 'PC' ]
 ---

--- a/website/content/fr/docs/v0.7/quickstart/_index.md
+++ b/website/content/fr/docs/v0.7/quickstart/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "bien débuter" ]
 tags: [ "linux", "dossier scanné", "session", "dossier de travail"  ]
-weight: 280
+weight: 70280
 ---
 
 # Introduction

--- a/website/content/fr/docs/v0.7/reference/_index.md
+++ b/website/content/fr/docs/v0.7/reference/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module", "processus"]
-weight: 340
+weight: 70340
 ---
 
 # Vue d'ensemble

--- a/website/content/fr/docs/v0.7/reference/modules/_index.md
+++ b/website/content/fr/docs/v0.7/reference/modules/_index.md
@@ -7,7 +7,7 @@ keywords: [ "modules et traitements ALS" ]
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "module", "traitement" ]
-weight: 345
+weight: 70345
 ---
 
 # Vue d'ensemble

--- a/website/content/fr/docs/v0.7/reference/modules/preprocess/_index.md
+++ b/website/content/fr/docs/v0.7/reference/modules/preprocess/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module", "calibration"]
-weight: 352
+weight: 70352
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/preprocess/dark_remove.md
+++ b/website/content/fr/docs/v0.7/reference/modules/preprocess/dark_remove.md
@@ -7,7 +7,7 @@ keywords: ["ALS soustraction de dark"]
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["traitement", "dark", "calibration"]
-weight: 354
+weight: 70354
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/preprocess/debayer.md
+++ b/website/content/fr/docs/v0.7/reference/modules/preprocess/debayer.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "traitement", "dématriçage", "calibration" ]
-weight: 355
+weight: 70355
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/preprocess/hot_remove.md
+++ b/website/content/fr/docs/v0.7/reference/modules/preprocess/hot_remove.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["traitement", "pixels chauds", "calibration"]
-weight: 353
+weight: 70353
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/process/_index.md
+++ b/website/content/fr/docs/v0.7/reference/modules/process/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module"]
-weight: 357
+weight: 70357
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/process/autostretch.md
+++ b/website/content/fr/docs/v0.7/reference/modules/process/autostretch.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "processus", "étirement", "ajustement d’image" ]
-weight: 358
+weight: 70358
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/process/levels.md
+++ b/website/content/fr/docs/v0.7/reference/modules/process/levels.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "processus", "niveaux", "ajustement d’image" ]
-weight: 359
+weight: 70359
 ---
 
 # Vue d’ensemble

--- a/website/content/fr/docs/v0.7/reference/modules/process/rgb-balance.md
+++ b/website/content/fr/docs/v0.7/reference/modules/process/rgb-balance.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "processus", "balance rvb", "ajustement d’image" ]
-weight: 360
+weight: 70360
 ---
 
 # Vue d’ensemble

--- a/website/content/fr/docs/v0.7/reference/modules/save.md
+++ b/website/content/fr/docs/v0.7/reference/modules/save.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module", "output", "dossier web", "dossier de travail", "save"]
-weight: 361
+weight: 70361
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/scanner.md
+++ b/website/content/fr/docs/v0.7/reference/modules/scanner.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "module", "input", "dossier scanné", "scanner", "profil" ]
-weight: 350
+weight: 70350
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/server.md
+++ b/website/content/fr/docs/v0.7/reference/modules/server.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module", "serveur", "utilitaire", "web", "diffusion"]
-weight: 362
+weight: 70362
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/reference/modules/stack.md
+++ b/website/content/fr/docs/v0.7/reference/modules/stack.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "module", "traitement", "stack", "seuil" ]
-weight: 356
+weight: 70356
 ---
 
 # Présentation

--- a/website/content/fr/docs/v0.7/releasenotes/_index.md
+++ b/website/content/fr/docs/v0.7/releasenotes/_index.md
@@ -5,7 +5,7 @@ author: ALS Team
 lastmod: 2025-10-27T10:13:07Z
 keywords: [ 'Notes de version ALS' ]
 tags: [ ]
-weight: 550
+weight: 70550
 ---
 
 ## Version 0.7 #{#0.7}

--- a/website/content/fr/docs/v0.7/userguide/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/_index.md
@@ -8,7 +8,7 @@ keywords: [ "guide utilisateur d'ALS" ]
 draft: false
 type: "docs"
 tags: [ "glossaire" , "typographie" ]
-weight: 300
+weight: 70300
 ---
 
 **Laissez-vous guider !** Nous allons vous montrer tout ce qu'il y a à savoir sur ALS pour une utilisation fluide et

--- a/website/content/fr/docs/v0.7/userguide/concepts.md
+++ b/website/content/fr/docs/v0.7/userguide/concepts.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "bien débuter" ]
 tags: [ "module", "stack", "traitement", "session","output", "dossier scanné", "dossier de travail", "dossier web", "serveur", "scanner", "save", "calibration", "profil" ]
-weight: 315
+weight: 70315
 ---
 
 # Introduction

--- a/website/content/fr/docs/v0.7/userguide/preferences/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/preferences/_index.md
@@ -7,7 +7,7 @@ keywords: ["préférences ALS"]
 type: "docs"
 categories: ["configuration"]
 tags: [ ]
-weight: 330
+weight: 70330
 ---
 
 La grande majorité de la configuration de l'application est faite via la fenêtre des **Préférences**

--- a/website/content/fr/docs/v0.7/userguide/preferences/general/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/preferences/general/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration", "dépannage"]
 tags: [ "dossier scanné", "memoire", "profil", "langue" ]
-weight: 331
+weight: 70331
 ---
 
 Les réglages les plus critiques d'ALS sont présentés dans l'onglet `Général`

--- a/website/content/fr/docs/v0.7/userguide/preferences/output/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/preferences/output/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: ["output", "serveur", "dossier web", "dossier de travail", "save"]
-weight: 333
+weight: 70333
 ---
 
 Les réglages régissant les sorties d'ALS présentés dans l'onglet `Sortie`.

--- a/website/content/fr/docs/v0.7/userguide/preferences/processing/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/preferences/processing/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: ["traitement", "dématriçage", "dark", "pixels chauds", "calibration"]
-weight: 332
+weight: 70332
 ---
 
 Les réglages des traitements d'ALS sont présentés dans l'onglet `Traitement`

--- a/website/content/fr/docs/v0.7/userguide/session.md
+++ b/website/content/fr/docs/v0.7/userguide/session.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "utilisation", "configuration" ]
 tags: [ "session", "serveur", "profil" ]
-weight: 317
+weight: 70317
 ---
 
 # 📘 Introduction

--- a/website/content/fr/docs/v0.7/userguide/ui/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/ui/_index.md
@@ -8,7 +8,7 @@ keywords: ["ALS GUI", "Interface ALS"]
 type: "docs"
 categories: ["utilisation"]
 tags: [ "interface", "panneaux" ]
-weight: 320
+weight: 70320
 ---
 
 # Introduction

--- a/website/content/fr/docs/v0.7/userguide/ui/controls/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/ui/controls/_index.md
@@ -7,7 +7,7 @@ keywords: [ "controles principaux d'ALS" ]
 type: "docs"
 categories: ["utilisation", "configuration"]
 tags: [ "stack", "session", "serveur", "output", "seuil", "save", "problèmes", "panneaux" ]
-weight: 321
+weight: 70321
 ---
 
 # Introduction

--- a/website/content/fr/docs/v0.7/userguide/ui/log/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/ui/log/_index.md
@@ -7,7 +7,7 @@ keywords: [ "journal de session", "suivi", "erreurs", "log", "panneaux" ]
 type: "docs"
 tags: [ "journal", "problèmes", "erreurs", "panneaux" ]
 categories: [ "utilisation", "dépannage" ]
-weight: 323
+weight: 70323
 ---
 
 # Introduction

--- a/website/content/fr/docs/v0.7/userguide/ui/menu/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/ui/menu/_index.md
@@ -8,7 +8,7 @@ keywords: ["ALS Menu"]
 type: "docs"
 categories: ["utilisation"]
 tags: [ ]
-weight: 325
+weight: 70325
 ---
 
 ## Fichier

--- a/website/content/fr/docs/v0.7/userguide/ui/processing/_index.md
+++ b/website/content/fr/docs/v0.7/userguide/ui/processing/_index.md
@@ -7,7 +7,7 @@ keywords: [ "traitements ALS", "histogramme", "auto stretch", "niveaux", "balanc
 type: "docs"
 tags: [ "histogramme", "stretch", "curseurs", "traitements", "panneaux" ]
 categories: [ "utilisation", "configuration" ]
-weight: 322
+weight: 70322
 ---
 
 # Introduction

--- a/website/content/fr/docs/v0.7/userguide/ui/shortcuts.md
+++ b/website/content/fr/docs/v0.7/userguide/ui/shortcuts.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "utilisation" ]
 tags: [ "" ]
-weight: 324
+weight: 70324
 ---
 
 <div class="row">

--- a/website/content/fr/docs/v1.0/_index.md
+++ b/website/content/fr/docs/v1.0/_index.md
@@ -3,7 +3,7 @@ title: Documentation ALS v1.0
 description: Documentation ALS v1.0
 author: ALZ Team
 lastmod: 2025-11-02T20:24:25Z
-weight: 10
+weight: 100010
 ---
 
 ALS est une application de livestacking.

--- a/website/content/fr/docs/v1.0/installation/_index.md
+++ b/website/content/fr/docs/v1.0/installation/_index.md
@@ -3,7 +3,7 @@ title: Installation
 description: installation d'ALS
 author: ALZ Team
 lastmod: 2025-11-02T19:02:52Z
-weight: 200
+weight: 100200
 Categories: ['procédures']
 ---
 

--- a/website/content/fr/docs/v1.0/installation/linux-install.md
+++ b/website/content/fr/docs/v1.0/installation/linux-install.md
@@ -4,7 +4,7 @@ description: Installation d'ALS sur PC Linux
 author: ALZ Team
 lastmod: 2025-11-02T19:02:52Z
 keywords: [ "installation", "linux", "astro live stacker", "guide" ]
-weight: 210
+weight: 100210
 Categories: ['procédures']
 tags: ['install', 'Linux', 'PC']
 ---

--- a/website/content/fr/docs/v1.0/installation/mac-arm-install.md
+++ b/website/content/fr/docs/v1.0/installation/mac-arm-install.md
@@ -5,7 +5,7 @@ author: ALZ Team
 
 lastmod: 2025-11-02T19:02:52Z
 keywords: ["installation", "mac", "m1", "m2", "astro live stacker", "guide"]
-weight: 240
+weight: 100240
 Categories: ['procédures']
 tags: ['install', 'Mac', 'Apple Silicon']
 ---

--- a/website/content/fr/docs/v1.0/installation/mac-intel-install.md
+++ b/website/content/fr/docs/v1.0/installation/mac-intel-install.md
@@ -5,7 +5,7 @@ author: ALZ Team
 
 lastmod: 2025-11-02T19:02:52Z
 keywords: ["installation", "mac", "intel", "astro live stacker", "guide"]
-weight: 240
+weight: 100240
 Categories: ['procédures']
 tags: ['install', 'Mac', 'Apple Intel']
 ---

--- a/website/content/fr/docs/v1.0/installation/raspberry-pi-install.md
+++ b/website/content/fr/docs/v1.0/installation/raspberry-pi-install.md
@@ -5,7 +5,7 @@ author: ALZ Team
 
 lastmod: 2025-11-02T19:02:52Z
 keywords: [ "installation", "raspberry pi", "linux", "astro live stacker", "guide" ]
-weight: 220
+weight: 100220
 Categories: ['procédures']
 tags: ['install', 'Linux', 'Raspberry Pi']
 ---

--- a/website/content/fr/docs/v1.0/installation/windows-install.md
+++ b/website/content/fr/docs/v1.0/installation/windows-install.md
@@ -4,7 +4,7 @@ description: Installation d'ALS sur PC Windows
 author: ALZ Team
 lastmod: 2025-11-02T19:02:52Z
 keywords: [ "installation ALS", "windows", "astro live stacker", "guide" ]
-weight: 230
+weight: 100230
 Categories: ['procédures']
 tags: [ 'install', 'Windows', 'PC' ]
 ---

--- a/website/content/fr/docs/v1.0/quickstart/_index.md
+++ b/website/content/fr/docs/v1.0/quickstart/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "bien débuter" ]
 tags: [ "linux", "dossier scanné", "session", "dossier de travail"  ]
-weight: 280
+weight: 100280
 ---
 
 # Introduction

--- a/website/content/fr/docs/v1.0/reference/_index.md
+++ b/website/content/fr/docs/v1.0/reference/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module", "processus"]
-weight: 340
+weight: 100340
 ---
 
 # Vue d'ensemble

--- a/website/content/fr/docs/v1.0/reference/modules/_index.md
+++ b/website/content/fr/docs/v1.0/reference/modules/_index.md
@@ -7,7 +7,7 @@ keywords: [ "modules et traitements ALS" ]
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "module", "traitement" ]
-weight: 345
+weight: 100345
 ---
 
 # Vue d'ensemble

--- a/website/content/fr/docs/v1.0/reference/modules/preprocess/_index.md
+++ b/website/content/fr/docs/v1.0/reference/modules/preprocess/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module", "calibration"]
-weight: 352
+weight: 100352
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/preprocess/dark_remove.md
+++ b/website/content/fr/docs/v1.0/reference/modules/preprocess/dark_remove.md
@@ -7,7 +7,7 @@ keywords: ["ALS soustraction de dark"]
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["traitement", "dark", "calibration"]
-weight: 354
+weight: 100354
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/preprocess/debayer.md
+++ b/website/content/fr/docs/v1.0/reference/modules/preprocess/debayer.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "traitement", "dématriçage", "calibration" ]
-weight: 355
+weight: 100355
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/preprocess/hot_remove.md
+++ b/website/content/fr/docs/v1.0/reference/modules/preprocess/hot_remove.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["traitement", "pixels chauds", "calibration"]
-weight: 353
+weight: 100353
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/process/_index.md
+++ b/website/content/fr/docs/v1.0/reference/modules/process/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module"]
-weight: 357
+weight: 100357
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/process/autostretch.md
+++ b/website/content/fr/docs/v1.0/reference/modules/process/autostretch.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "processus", "étirement", "ajustement d’image" ]
-weight: 358
+weight: 100358
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/process/levels.md
+++ b/website/content/fr/docs/v1.0/reference/modules/process/levels.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "processus", "niveaux", "ajustement d’image" ]
-weight: 359
+weight: 100359
 ---
 
 # Vue d’ensemble

--- a/website/content/fr/docs/v1.0/reference/modules/process/rgb-balance.md
+++ b/website/content/fr/docs/v1.0/reference/modules/process/rgb-balance.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "processus", "balance rvb", "ajustement d’image" ]
-weight: 360
+weight: 100360
 ---
 
 # Vue d’ensemble

--- a/website/content/fr/docs/v1.0/reference/modules/save.md
+++ b/website/content/fr/docs/v1.0/reference/modules/save.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module", "output", "dossier web", "dossier de travail", "save"]
-weight: 361
+weight: 100361
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/scanner.md
+++ b/website/content/fr/docs/v1.0/reference/modules/scanner.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "module", "input", "dossier scanné", "scanner", "profil" ]
-weight: 350
+weight: 100350
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/server.md
+++ b/website/content/fr/docs/v1.0/reference/modules/server.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["documentations détaillées"]
 tags: ["module", "serveur", "utilitaire", "web", "diffusion"]
-weight: 362
+weight: 100362
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/stack.md
+++ b/website/content/fr/docs/v1.0/reference/modules/stack.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "module", "traitement", "stack", "seuil" ]
-weight: 356
+weight: 100356
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/releasenotes/_index.md
+++ b/website/content/fr/docs/v1.0/releasenotes/_index.md
@@ -5,7 +5,7 @@ author: ALS Team
 lastmod: 2025-11-02T19:02:52Z
 keywords: [ 'Notes de version ALS' ]
 tags: [ ]
-weight: 550
+weight: 100550
 ---
 
 ## Version 0.7 #{#0.7}

--- a/website/content/fr/docs/v1.0/userguide/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/_index.md
@@ -8,7 +8,7 @@ keywords: [ "guide utilisateur d'ALS" ]
 draft: false
 type: "docs"
 tags: [ "glossaire" , "typographie" ]
-weight: 300
+weight: 100300
 ---
 
 **Laissez-vous guider !** Nous allons vous montrer tout ce qu'il y a à savoir sur ALS pour une utilisation fluide et

--- a/website/content/fr/docs/v1.0/userguide/concepts.md
+++ b/website/content/fr/docs/v1.0/userguide/concepts.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "bien débuter" ]
 tags: [ "module", "stack", "traitement", "session","output", "dossier scanné", "dossier de travail", "dossier web", "serveur", "scanner", "save", "calibration", "profil" ]
-weight: 315
+weight: 100315
 ---
 
 # Introduction

--- a/website/content/fr/docs/v1.0/userguide/preferences/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/preferences/_index.md
@@ -7,7 +7,7 @@ keywords: ["préférences ALS"]
 type: "docs"
 categories: ["configuration"]
 tags: [ ]
-weight: 330
+weight: 100330
 ---
 
 La grande majorité de la configuration de l'application est faite via la fenêtre des **Préférences**

--- a/website/content/fr/docs/v1.0/userguide/preferences/general/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/preferences/general/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration", "dépannage"]
 tags: [ "dossier scanné", "memoire", "profil", "langue" ]
-weight: 331
+weight: 100331
 ---
 
 Les réglages les plus critiques d'ALS sont présentés dans l'onglet `Général`

--- a/website/content/fr/docs/v1.0/userguide/preferences/output/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/preferences/output/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: ["output", "serveur", "dossier web", "dossier de travail", "save"]
-weight: 333
+weight: 100333
 ---
 
 Les réglages régissant les sorties d'ALS présentés dans l'onglet `Sortie`.

--- a/website/content/fr/docs/v1.0/userguide/preferences/processing/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/preferences/processing/_index.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: ["configuration"]
 tags: ["traitement", "dématriçage", "dark", "pixels chauds", "calibration"]
-weight: 332
+weight: 100332
 ---
 
 Les réglages des traitements d'ALS sont présentés dans l'onglet `Traitement`

--- a/website/content/fr/docs/v1.0/userguide/session.md
+++ b/website/content/fr/docs/v1.0/userguide/session.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "utilisation", "configuration" ]
 tags: [ "session", "serveur", "profil" ]
-weight: 317
+weight: 100317
 ---
 
 # 📘 Introduction

--- a/website/content/fr/docs/v1.0/userguide/ui/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/_index.md
@@ -8,7 +8,7 @@ keywords: ["ALS GUI", "Interface ALS"]
 type: "docs"
 categories: ["utilisation"]
 tags: [ "interface", "panneaux" ]
-weight: 320
+weight: 100320
 ---
 
 # Introduction

--- a/website/content/fr/docs/v1.0/userguide/ui/controls/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/controls/_index.md
@@ -7,7 +7,7 @@ keywords: [ "controles principaux d'ALS" ]
 type: "docs"
 categories: ["utilisation", "configuration"]
 tags: [ "stack", "session", "serveur", "output", "seuil", "save", "problèmes", "panneaux" ]
-weight: 321
+weight: 100321
 ---
 
 # Introduction

--- a/website/content/fr/docs/v1.0/userguide/ui/log/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/log/_index.md
@@ -7,7 +7,7 @@ keywords: [ "journal de session", "suivi", "erreurs", "log", "panneaux" ]
 type: "docs"
 tags: [ "journal", "problèmes", "erreurs", "panneaux" ]
 categories: [ "utilisation", "dépannage" ]
-weight: 323
+weight: 100323
 ---
 
 # Introduction

--- a/website/content/fr/docs/v1.0/userguide/ui/menu/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/menu/_index.md
@@ -8,7 +8,7 @@ keywords: ["ALS Menu"]
 type: "docs"
 categories: ["utilisation"]
 tags: [ ]
-weight: 325
+weight: 100325
 ---
 
 ## Fichier

--- a/website/content/fr/docs/v1.0/userguide/ui/processing/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/processing/_index.md
@@ -7,7 +7,7 @@ keywords: [ "traitements ALS", "histogramme", "auto stretch", "niveaux", "balanc
 type: "docs"
 tags: [ "histogramme", "stretch", "curseurs", "traitements", "panneaux" ]
 categories: [ "utilisation", "configuration" ]
-weight: 322
+weight: 100322
 ---
 
 # Introduction

--- a/website/content/fr/docs/v1.0/userguide/ui/shortcuts.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/shortcuts.md
@@ -9,7 +9,7 @@ draft: false
 type: "docs"
 categories: [ "utilisation" ]
 tags: [ "" ]
-weight: 324
+weight: 100324
 ---
 
 <div class="row">


### PR DESCRIPTION
## Summary
- increase ordering weights for all v0.7 documentation pages by 70,000
- raise ordering weights for all v1.0 documentation pages by 100,000

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690853e74ef8832b81aabd6b25613c75