### PR TITLE
Add flat calibration documentation for v1.0

### DIFF
--- a/website/content/en/docs/v1.0/reference/modules/preprocess/debayer.md
+++ b/website/content/en/docs/v1.0/reference/modules/preprocess/debayer.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "detailed documentations" ]
 tags: [ "process", "debayer", "calibration" ]
-weight: 100355
+weight: 100356
 ---
 
 # Overview

--- a/website/content/en/docs/v1.0/reference/modules/preprocess/flat_calibration.md
+++ b/website/content/en/docs/v1.0/reference/modules/preprocess/flat_calibration.md
@@ -1,0 +1,102 @@
+---
+title: "Flat Calibration"
+description: "Detailed documentation of the ALS FlatCalibration process"
+author: "ALS Team"
+lastmod: 2025-11-02T19:02:51Z
+keywords: ["ALS flat calibration", "ALS flat field"]
+draft: false
+type: "docs"
+categories: ["detailed documentations"]
+tags: ["process", "flat", "calibration"]
+weight: 100355
+---
+
+# Overview
+
+The **FlatCalibration** process removes pixel-to-pixel illumination variations by normalizing the image
+with a user-provided master flat frame.
+
+Its configuration is managed via the ALS preferences page.
+
+# Configuration
+
+|                   | Source                                                                                  | Data type | Required | Default value |
+|-------------------|-----------------------------------------------------------------------------------------|-----------|----------|----------------|
+| ON/OFF            | Preferences: [Processing Tab](../../../userguide/preferences/processing/#flat)          | ON/OFF    | ∅        | OFF            |
+| Master flat path  | Preferences: [Processing Tab](../../../userguide/preferences/processing/#flat)          | File path | Yes      | ∅              |
+| Auto normalize    | Preferences: [Processing Tab](../../../userguide/preferences/processing/#flat)          | ON/OFF    | ∅        | ON             |
+| Normalization ROI | Preferences: [Processing Tab](../../../userguide/preferences/processing/#flat)          | Rectangle | No       | Full frame     |
+
+# Control
+
+This process is triggered by the **Preprocess** pipeline after dark removal and before debayering.
+
+# Input
+
+| Data                                            | Type  |
+|-------------------------------------------------|-------|
+| image received from the **Preprocess** pipeline | Image |
+| master flat read from configured path           | Image |
+
+# Behavior
+
+```mermaid
+graph LR
+
+START([START])
+
+TEST_ENABLED{{Processing enabled?}}
+TEST_SIZE{{Identical dimensions?}}
+TEST_TYPE{{Identical data types?}}
+TEST_NORMALIZE{{Normalization required?}}
+TEST_SAFE{{Flat frame safe to use?}}
+
+LOAD[Load master flat]
+NORM[Normalize master flat]
+CALIBRATE[Divide image by master flat]
+RETURN[Return modified image]
+UNCHANGED[Return unchanged image]
+
+END([END])
+
+START --> TEST_ENABLED
+TEST_ENABLED -- No --> UNCHANGED
+TEST_ENABLED -- Yes --> LOAD
+
+LOAD --> TEST_SAFE
+TEST_SAFE -- No --> UNCHANGED
+TEST_SAFE -- Yes --> TEST_SIZE
+
+TEST_SIZE -- No --> UNCHANGED
+TEST_SIZE -- Yes --> TEST_TYPE
+
+TEST_TYPE -- No --> NORM
+TEST_TYPE -- Yes --> TEST_NORMALIZE
+
+NORM --> TEST_NORMALIZE
+TEST_NORMALIZE -- Yes --> CALIBRATE
+TEST_NORMALIZE -- No --> CALIBRATE
+
+CALIBRATE --> RETURN
+RETURN --> END
+UNCHANGED --> END
+
+classDef bounds fill:#333,stroke:#666,stroke-width:2px,color:#BBB,font-family:'Poppins',sans-serif
+classDef step fill:#444,stroke:#622,stroke-width:2px,color:#c6c6c6,font-family:'Poppins',sans-serif
+classDef test fill:#444,stroke:#226,stroke-width:2px,color:#c6c6c6,font-family:'Poppins',sans-serif
+
+class START,END bounds
+class LOAD,NORM,CALIBRATE,RETURN,UNCHANGED step
+class TEST_ENABLED,TEST_SIZE,TEST_TYPE,TEST_NORMALIZE,TEST_SAFE test
+```
+
+The master flat is loaded and optionally normalized before being used to calibrate the incoming image.
+
+- If the frame dimensions differ, the process is aborted and the **unmodified** image is returned to the **Preprocess** module.
+- If data types differ, the master flat is converted to match the input image before calibration.
+- If automatic normalization is enabled, the master flat is scaled so that its mean value over the selected ROI equals 1.0.
+- Pixels that would lead to division by zero are clipped to a minimum safe value before the calibration step.
+
+# Output
+
+The calibrated image is sent back to the **Preprocess** pipeline.

--- a/website/content/en/docs/v1.0/userguide/preferences/processing/_index.md
+++ b/website/content/en/docs/v1.0/userguide/preferences/processing/_index.md
@@ -23,6 +23,7 @@ This tab contains only one section: [Preprocess](#preprocess)
 It gathers the settings for all **calibration** tasks:
 - [Hot pixel removal](#hot-remove)
 - [Dark subtraction](#dark-remove)
+- [Flat calibration](#flat)
 - [Debayering](#debayer)
 
 </div>
@@ -91,6 +92,24 @@ If the dimensions are different:
   In case of a difference (_e.g., master dark in 32-bit floats and raw in 16-bit integers_):
   - The master dark is converted before use
   - The format difference is discreetly noted in the session log
+{{% /alert %}}
+
+ℹ️ Default : OFF
+
+## Flat calibration {#flat}
+
+- 🖱️ Check `Active` to enable flat calibration
+- 🖱️ Click `Master flat...` to select the master flat frame used for normalization
+- 🖱️ Click `Clear` to reset the master flat path
+- 🖱️ Toggle `Auto normalize` to scale the master flat automatically
+- 🖱️ Adjust the optional ROI fields to restrict normalization to a specific area
+
+{{% alert color="warning" %}}
+⚠️ The master flat **must have the same dimensions** (_width x height_) as the image to be processed
+{{% /alert %}}
+
+{{% alert color="info" %}}
+ℹ️ When auto normalization is enabled, ALS computes the mean signal inside the selected ROI (or the whole frame if no ROI is set) and scales the master flat so that the mean equals 1.0.
 {{% /alert %}}
 
 ℹ️ Default : OFF

--- a/website/content/fr/docs/v1.0/reference/modules/preprocess/debayer.md
+++ b/website/content/fr/docs/v1.0/reference/modules/preprocess/debayer.md
@@ -8,7 +8,7 @@ draft: false
 type: "docs"
 categories: [ "documentations détaillées" ]
 tags: [ "traitement", "dématriçage", "calibration" ]
-weight: 100355
+weight: 100356
 ---
 
 # Présentation

--- a/website/content/fr/docs/v1.0/reference/modules/preprocess/flat_calibration.md
+++ b/website/content/fr/docs/v1.0/reference/modules/preprocess/flat_calibration.md
@@ -1,0 +1,101 @@
+---
+title: "Calibration par flat"
+description: "Documentation détaillée du traitement FlatCalibration d'ALS"
+author: "ALS Team"
+lastmod: 2025-11-02T19:02:52Z
+keywords: ["ALS calibration par flat", "ALS flat field"]
+type: "docs"
+categories: ["documentations détaillées"]
+tags: ["traitement", "flat", "calibration"]
+weight: 100355
+---
+
+# Présentation
+
+Le traitement **FlatCalibration** supprime les variations d'éclairage pixel à pixel en normalisant l'image
+avec un master flat fourni par l'utilisateur.
+
+Sa configuration est gérée via la page des préférences d'ALS.
+
+# Configuration
+
+|                        | Source                                                                                     | Type de donnée        | Requis | Valeur par défaut |
+|------------------------|---------------------------------------------------------------------------------------------|-----------------------|--------|-------------------|
+| ON/OFF                 | Préférences : [Onglet Traitement](../../../userguide/preferences/processing/#flat)          | ON/OFF                | ∅      | OFF               |
+| Chemin du master flat  | Préférences : [Onglet Traitement](../../../userguide/preferences/processing/#flat)          | Chemin vers un fichier | OUI    | ∅                 |
+| Normalisation auto     | Préférences : [Onglet Traitement](../../../userguide/preferences/processing/#flat)          | ON/OFF                | ∅      | ON                |
+| ROI de normalisation   | Préférences : [Onglet Traitement](../../../userguide/preferences/processing/#flat)          | Rectangle             | Non    | Pleine image      |
+
+# Contrôle
+
+Ce traitement est déclenché par le pipeline **Preprocess** après la soustraction de dark et avant le débayering.
+
+# Entrée
+
+| Donnée                                       | Type  |
+|----------------------------------------------|-------|
+| image fournie par le pipeline **Preprocess** | Image |
+| master flat lu depuis le chemin configuré    | Image |
+
+# Comportement
+
+```mermaid
+graph LR
+
+START([START])
+
+TEST_ENABLED{{Traitement activé ?}}
+TEST_SIZE{{Dimensions identiques ?}}
+TEST_TYPE{{Types de données identiques ?}}
+TEST_NORMALIZE{{Normalisation nécessaire ?}}
+TEST_SAFE{{Master flat exploitable ?}}
+
+LOAD[Chargement du master flat]
+NORM[Normaliser le master flat]
+CALIBRATE[Diviser l'image par le master flat]
+RETURN[Retourner l'image modifiée]
+UNCHANGED[Retourner l'image inchangée]
+
+END([END])
+
+START --> TEST_ENABLED
+TEST_ENABLED -- Non --> UNCHANGED
+TEST_ENABLED -- Oui --> LOAD
+
+LOAD --> TEST_SAFE
+TEST_SAFE -- Non --> UNCHANGED
+TEST_SAFE -- Oui --> TEST_SIZE
+
+TEST_SIZE -- Non --> UNCHANGED
+TEST_SIZE -- Oui --> TEST_TYPE
+
+TEST_TYPE -- Non --> NORM
+TEST_TYPE -- Oui --> TEST_NORMALIZE
+
+NORM --> TEST_NORMALIZE
+TEST_NORMALIZE -- Oui --> CALIBRATE
+TEST_NORMALIZE -- Non --> CALIBRATE
+
+CALIBRATE --> RETURN
+RETURN --> END
+UNCHANGED --> END
+
+classDef bounds fill:#333,stroke:#666,stroke-width:2px,color:#BBB,font-family:'Poppins',sans-serif
+classDef step fill:#444,stroke:#622,stroke-width:2px,color:#c6c6c6,font-family:'Poppins',sans-serif
+classDef test fill:#444,stroke:#226,stroke-width:2px,color:#c6c6c6,font-family:'Poppins',sans-serif
+
+class START,END bounds
+class LOAD,NORM,CALIBRATE,RETURN,UNCHANGED step
+class TEST_ENABLED,TEST_SIZE,TEST_TYPE,TEST_NORMALIZE,TEST_SAFE test
+```
+
+Le master flat est chargé puis éventuellement normalisé avant d'être utilisé pour calibrer l'image entrante.
+
+- Si les dimensions diffèrent, le traitement est abandonné et l'image **non modifiée** est renvoyée au module **Preprocess**.
+- Si les types de données diffèrent, le master flat est converti pour correspondre à l'image avant la calibration.
+- Si la normalisation automatique est activée, le master flat est mis à l'échelle pour que sa valeur moyenne sur la ROI sélectionnée soit égale à 1,0.
+- Les pixels susceptibles de provoquer une division par zéro sont limités à une valeur minimale sûre avant l'étape de calibration.
+
+# Sortie
+
+L'image calibrée est renvoyée au pipeline **Preprocess**.

--- a/website/content/fr/docs/v1.0/userguide/preferences/processing/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/preferences/processing/_index.md
@@ -23,6 +23,7 @@ Cet onglet ne contient qu'une seule section : [Preprocess](#preprocess)
 Elle regroupe les réglages des tâches de **calibration** :
 - [Suppression des pixels chauds](#hot-remove)
 - [Soustraction de dark](#dark-remove)
+- [Calibration par flat](#flat)
 - [Dématriçage](#debayer)
 
 </div>
@@ -92,6 +93,24 @@ Si les dimensions sont différentes :
   En cas de différence (_ex. master dark en flottants 32bits et brute en entiers 16bits_) : 
   - le master dark est converti avant son utilisation
   - la différence de format est signalée discrètement dans le journal de session
+{{% /alert %}}
+
+ℹ️ Par défaut : OFF
+
+## Calibration par flat {#flat}
+
+- 🖱️ Cochez `Active` pour activer la calibration par flat
+- 🖱️ Cliquez sur `Master flat...` pour sélectionner le master flat utilisé pour la normalisation
+- 🖱️ Cliquez sur `Vider` pour réinitialiser le chemin du master flat
+- 🖱️ Activez ou désactivez `Normalisation auto` pour laisser ALS mettre à l'échelle le master flat
+- 🖱️ Ajustez les champs de ROI optionnels pour limiter la normalisation à une zone précise
+
+{{% alert color="warning" %}}
+⚠️ Le master flat **doit avoir les mêmes dimensions** (_largeur x hauteur_) que l'image à traiter
+{{% /alert %}}
+
+{{% alert color="info" %}}
+ℹ️ Quand la normalisation automatique est active, ALS calcule le signal moyen dans la ROI sélectionnée (ou l'image entière si aucune ROI n'est définie) et met le master flat à l'échelle pour que cette moyenne vaille 1,0.
 {{% /alert %}}
 
 ℹ️ Par défaut : OFF


### PR DESCRIPTION
## Summary
- add detailed English and French reference documentation for the flat calibration preprocess stage, including workflow diagrams
- update the preferences documentation to describe flat calibration settings alongside other preprocessing tasks
- adjust preprocess module weights so flat calibration appears between dark subtraction and debayering in navigation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_6908660072fc832b84f321b260cb6e02