### PR TITLE
Add saturation slider to color balance controls

### DIFF
--- a/src/als/model/data.py
+++ b/src/als/model/data.py
@@ -64,6 +64,7 @@ class I18n(QObject):
     TOOLTIP_RED_LEVEL = "TEMP"
     TOOLTIP_GREEN_LEVEL = "TEMP"
     TOOLTIP_BLUE_LEVEL = "TEMP"
+    TOOLTIP_SATURATION_LEVEL = "TEMP"
     TOOLTIP_STRETCH_STRENGTH = "TEMP"
     TOOLTIP_RGB_ACTIVE = "TEMP"
     TOOLTIP_STRETCH_ACTIVE = "TEMP"
@@ -96,6 +97,7 @@ class I18n(QObject):
         I18n.TOOLTIP_RED_LEVEL = self.tr("Red level")
         I18n.TOOLTIP_GREEN_LEVEL = self.tr("Green level")
         I18n.TOOLTIP_BLUE_LEVEL = self.tr("Blue level")
+        I18n.TOOLTIP_SATURATION_LEVEL = self.tr("Color saturation")
         I18n.TOOLTIP_BLACK_LEVEL = self.tr("Black clipping")
         I18n.TOOLTIP_MIDTONES_LEVEL = self.tr("Midtones level")
         I18n.TOOLTIP_WHITE_LEVEL = self.tr("White clipping")

--- a/src/als/processing.py
+++ b/src/als/processing.py
@@ -79,6 +79,8 @@ class ColorBalance(ImageProcessor):
     Implements color balance processing
     """
 
+    _HISTOGRAM_BIN_COUNT = 512
+
     @log
     def __init__(self):
 
@@ -171,13 +173,33 @@ class ColorBalance(ImageProcessor):
 
             if not saturation.is_default():
                 mean_channel = np.mean(image.data, axis=0)
-                image.data = mean_channel + (image.data - mean_channel) * saturation.value
-                processed = True
+                saturation_mask = self._build_saturation_mask(mean_channel)
+                if np.any(saturation_mask):
+                    saturated_data = mean_channel + (image.data - mean_channel) * saturation.value
+                    image.data = np.where(saturation_mask, saturated_data, image.data)
+                    processed = True
 
             if processed:
                 image.data = np.clip(image.data, 0, _16_BITS_MAX_VALUE)
 
         return image
+
+    @staticmethod
+    def _build_saturation_mask(luminance: np.ndarray) -> np.ndarray:
+        histogram, bin_edges = np.histogram(
+            luminance, ColorBalance._HISTOGRAM_BIN_COUNT, range=(0, _16_BITS_MAX_VALUE)
+        )
+
+        peak_index = int(np.argmax(histogram))
+        descending_end_index = len(histogram)
+
+        for index in range(peak_index + 1, len(histogram)):
+            if histogram[index] >= histogram[index - 1]:
+                descending_end_index = index
+                break
+
+        threshold_value = bin_edges[descending_end_index]
+        return luminance >= threshold_value
 
 
 class AutoStretch(ImageProcessor):

--- a/src/als/processing.py
+++ b/src/als/processing.py
@@ -122,6 +122,16 @@ class ColorBalance(ImageProcessor):
             )
         )
 
+        self._parameters.append(
+            RangeParameter(
+                "saturation",
+                I18n.TOOLTIP_SATURATION_LEVEL,
+                default=1,
+                minimum=0,
+                maximum=2
+            )
+        )
+
     @log
     def process_image(self, image: Image):
         """
@@ -138,6 +148,7 @@ class ColorBalance(ImageProcessor):
         red = self._parameters[1]
         green = self._parameters[2]
         blue = self._parameters[3]
+        saturation = self._parameters[4]
 
         if active.value:
             red_value = red.value if red.value > 0 else 0.1
@@ -156,6 +167,11 @@ class ColorBalance(ImageProcessor):
 
             if not blue.is_default():
                 image.data[2] = image.data[2] * blue_value
+                processed = True
+
+            if not saturation.is_default():
+                mean_channel = np.mean(image.data, axis=0)
+                image.data = mean_channel + (image.data - mean_channel) * saturation.value
                 processed = True
 
             if processed:

--- a/src/als/processing.py
+++ b/src/als/processing.py
@@ -173,10 +173,14 @@ class ColorBalance(ImageProcessor):
 
             if not saturation.is_default():
                 mean_channel = np.mean(image.data, axis=0)
-                saturation_mask = self._build_saturation_mask(mean_channel)
-                if np.any(saturation_mask):
-                    saturated_data = mean_channel + (image.data - mean_channel) * saturation.value
-                    image.data = np.where(saturation_mask, saturated_data, image.data)
+                if saturation.value > saturation.default:
+                    saturation_mask = self._build_saturation_mask(mean_channel)
+                    if np.any(saturation_mask):
+                        saturated_data = mean_channel + (image.data - mean_channel) * saturation.value
+                        image.data = np.where(saturation_mask, saturated_data, image.data)
+                        processed = True
+                else:
+                    image.data = mean_channel + (image.data - mean_channel) * saturation.value
                     processed = True
 
             if processed:

--- a/src/als/ui/als_ui.ui
+++ b/src/als/ui/als_ui.ui
@@ -1228,6 +1228,23 @@
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Saturation</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Slider" name="sld_rgb_saturation">
+            <property name="maximum">
+             <number>255</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item>

--- a/src/als/ui/windows.py
+++ b/src/als/ui/windows.py
@@ -83,13 +83,14 @@ class MainWindow(QMainWindow):
             self._ui.sld_rgb_r,
             self._ui.sld_rgb_g,
             self._ui.sld_rgb_b,
+            self._ui.sld_rgb_saturation,
         ]
 
         self._rgb_parameters = self._controller.get_rgb_parameters()
 
         set_sliders_defaults(
-            [self._rgb_parameters[1], self._rgb_parameters[2], self._rgb_parameters[3]],
-            [self._ui.sld_rgb_r, self._ui.sld_rgb_g, self._ui.sld_rgb_b]
+            [self._rgb_parameters[1], self._rgb_parameters[2], self._rgb_parameters[3], self._rgb_parameters[4]],
+            [self._ui.sld_rgb_r, self._ui.sld_rgb_g, self._ui.sld_rgb_b, self._ui.sld_rgb_saturation]
         )
 
         init_params(self._rgb_parameters, self._rgb_controls)
@@ -258,6 +259,7 @@ class MainWindow(QMainWindow):
         self._ui.sld_rgb_r.setEnabled(checked)
         self._ui.sld_rgb_g.setEnabled(checked)
         self._ui.sld_rgb_b.setEnabled(checked)
+        self._ui.sld_rgb_saturation.setEnabled(checked)
 
         self._apply_rgb()
 

--- a/website/content/en/docs/v1.0/reference/modules/process/rgb-balance.md
+++ b/website/content/en/docs/v1.0/reference/modules/process/rgb-balance.md
@@ -52,6 +52,7 @@ The **RGB Balance** process is managed through the `Processing Panel` interface.
 # Behavior {#behavior}
 
 Balances the image’s color components and global saturation to achieve the desired tonal balance.
+Boosting saturation above its default only affects pixels in the histogram’s post-peak descending slope, while reductions apply uniformly across the image.
 
 # Output
 

--- a/website/content/en/docs/v1.0/reference/modules/process/rgb-balance.md
+++ b/website/content/en/docs/v1.0/reference/modules/process/rgb-balance.md
@@ -13,8 +13,9 @@ weight: 100360
 
 # Overview
 
-The **RGB Balance** process adjusts the relative intensity of the three primary colors — red, green, and blue — to correct or refine the overall color tone of a stacked image.  
-It allows fine control of image chromatic balance, complementing the **Levels** and **Auto-Stretch** processes.
+The **RGB Balance** process adjusts the relative intensity of the three primary colors — red, green, and blue — to correct or refine the overall color tone of a stacked image.
+It also controls global color **saturation**, letting you reinforce or tame chroma while keeping exposure unchanged.
+These parameters allow fine control of image chromatic balance, complementing the **Levels** and **Auto-Stretch** processes.
 
 This process is handled by the **Process** pipeline module.
 
@@ -34,12 +35,13 @@ instructions.
 
 The **RGB Balance** process is managed through the `Processing Panel` interface.
 
-| Control  | Type     | Action                              |
-|----------|----------|-------------------------------------|
-| `Active` | checkbox | Enable or disable the process       |
-| `R`      | slider   | Adjusts the red channel intensity   |
-| `G`      | slider   | Adjusts the green channel intensity |
-| `B`      | slider   | Adjusts the blue channel intensity  |
+| Control       | Type     | Action                                                       |
+|---------------|----------|--------------------------------------------------------------|
+| `Active`      | checkbox | Enable or disable the process                                |
+| `R`           | slider   | Adjusts the red channel intensity                            |
+| `G`           | slider   | Adjusts the green channel intensity                          |
+| `B`           | slider   | Adjusts the blue channel intensity                           |
+| `Saturation`  | slider   | Boosts or reduces color saturation without changing exposure |
 
 # Input
 
@@ -49,7 +51,7 @@ The **RGB Balance** process is managed through the `Processing Panel` interface.
 
 # Behavior {#behavior}
 
-Balances the image’s color components to achieve the desired tonal balance.
+Balances the image’s color components and global saturation to achieve the desired tonal balance.
 
 # Output
 

--- a/website/content/en/docs/v1.0/userguide/concepts.md
+++ b/website/content/en/docs/v1.0/userguide/concepts.md
@@ -191,9 +191,9 @@ The **Process** module groups the visual processing applied to the stacking resu
 
    Allows adjusting the black and white clipping, and the mid-tone level.
 
-3. **RGB balance**
+3. **RGB balance & saturation**
 
-   Allows adjusting the color balance.
+   Allows adjusting the color balance and saturation.
 
 {{% alert color="info" %}}
 ℹ️ The image displayed in ALS's **central area** is replaced by each image output from the **Process** module.

--- a/website/content/en/docs/v1.0/userguide/ui/processing/_index.md
+++ b/website/content/en/docs/v1.0/userguide/ui/processing/_index.md
@@ -254,6 +254,9 @@ The blended colors of the histogram effectively reflect the image's red dominanc
 
 ### Slider Actions
 
-Each slider adjusts the horizontal position of its respective curve.
-
-*Moving the slider to the right shifts the curve to the right.*
+- The **R**, **G**, and **B** sliders adjust the horizontal position of their respective curves.
+  *Moving the slider to the right shifts the curve to the right.*
+- The **Saturation** slider controls how far each channel can move away from neutral gray:
+  - Left = desaturate toward monochrome.
+  - Center = neutral (no change).
+  - Right = boost color intensity without altering exposure.

--- a/website/content/fr/docs/v1.0/reference/modules/process/rgb-balance.md
+++ b/website/content/fr/docs/v1.0/reference/modules/process/rgb-balance.md
@@ -51,6 +51,7 @@ Le processus **Balance RVB** est contrôlé via l’interface du panneau `traite
 # Comportement {#behavior}
 
 Balance les composantes colorimétriques et la saturation globale de l’image pour obtenir la tonalité souhaitée.
+L’augmentation de la saturation au-delà de sa valeur par défaut ne touche que les pixels situés sur la pente descendante après le pic de l’histogramme de luminance, tandis que les diminutions s’appliquent uniformément à l’ensemble de l’image.
 
 # Sortie
 

--- a/website/content/fr/docs/v1.0/reference/modules/process/rgb-balance.md
+++ b/website/content/fr/docs/v1.0/reference/modules/process/rgb-balance.md
@@ -13,8 +13,9 @@ weight: 100360
 
 # Vue d’ensemble
 
-Le processus **Balance RVB** ajuste l’intensité relative des trois couleurs primaires — rouge, vert et bleu — afin de corriger ou d’affiner la tonalité globale d’une image empilée.  
-Il offre un contrôle précis de la balance chromatique, en complément des processus **Niveaux** et **Auto-Stretch**.
+Le processus **Balance RVB** ajuste l’intensité relative des trois couleurs primaires — rouge, vert et bleu — afin de corriger ou d’affiner la tonalité globale d’une image empilée.
+Il contrôle aussi la **saturation** globale, pour renforcer ou atténuer la chroma sans modifier l’exposition.
+Ces paramètres offrent un contrôle précis de la balance chromatique, en complément des processus **Niveaux** et **Auto-Stretch**.
 
 Ce processus est géré par le module **Process** de la chaîne de traitement.
 
@@ -33,12 +34,13 @@ pour des instructions détaillées.
 
 Le processus **Balance RVB** est contrôlé via l’interface du panneau `traitements`.
 
-| Contrôle   | Type          | Action                               |
-|------------|---------------|--------------------------------------|
-| `Actif`    | case à cocher | Active ou désactiver le processus    |
-| `R`        | curseur       | Ajuste l’intensité du canal rouge    |
-| `V`        | curseur       | Ajuste l’intensité du canal vert     |
-| `B`        | curseur       | Ajuste l’intensité du canal bleu     |
+| Contrôle      | Type          | Action                                              |
+|---------------|---------------|-----------------------------------------------------|
+| `Actif`       | case à cocher | Active ou désactiver le processus                   |
+| `R`           | curseur       | Ajuste l’intensité du canal rouge                   |
+| `V`           | curseur       | Ajuste l’intensité du canal vert                    |
+| `B`           | curseur       | Ajuste l’intensité du canal bleu                    |
+| `Saturation`  | curseur       | Renforce ou réduit la saturation sans changer l’exposition |
 
 # Entrée
 
@@ -48,7 +50,7 @@ Le processus **Balance RVB** est contrôlé via l’interface du panneau `traite
 
 # Comportement {#behavior}
 
-Balance les composantes colorimétriques de l’image pour obtenir la tonalité souhaitée.
+Balance les composantes colorimétriques et la saturation globale de l’image pour obtenir la tonalité souhaitée.
 
 # Sortie
 

--- a/website/content/fr/docs/v1.0/userguide/concepts.md
+++ b/website/content/fr/docs/v1.0/userguide/concepts.md
@@ -195,9 +195,9 @@ Le module **Process** regroupe les traitements visuels appliqués sur les résul
 
    Permet de régler l'écrêtage des noirs et des blancs, et le niveau des tons moyens de l'image
 
-3. **Balance RVB**
+3. **Balance RVB et saturation**
 
-   Permet de régler la balance des couleurs de l'image
+   Permet de régler la balance des couleurs et la saturation de l'image
 
 {{% alert color="info" %}}
 ℹ️ L'image affichée dans la **zone centrale** d'ALS est remplacée par chaque image se présentant en sortie du module

--- a/website/content/fr/docs/v1.0/userguide/ui/processing/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/processing/_index.md
@@ -269,6 +269,9 @@ Le mélange des couleurs de l'histogramme rend bien compte de la dominante rouge
 
 ### Actions des Curseurs
 
-Chaque curseur ajuste la position horizontale de la courbe correspondante.
-
-*Déplacer le curseur vers la droite décale la courbe vers la droite*
+- Les curseurs **R**, **V** et **B** ajustent la position horizontale de leurs courbes respectives.
+  *Déplacer le curseur vers la droite décale la courbe vers la droite.*
+- Le curseur de **saturation** contrôle l'éloignement des canaux par rapport au gris neutre :
+  - À gauche = désaturer jusqu'au monochrome.
+  - Au centre = neutre (pas de changement).
+  - À droite = renforcer l'intensité des couleurs sans modifier l'exposition.


### PR DESCRIPTION
## Summary
- add a saturation slider to the RGB Balance UI group
- wire the new control through the window initialization and enablement logic
- extend color balance processing to apply saturation adjustments

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d013a0034832ba2a8a6afe2af83a1)