### PR TITLE
Fix MR pipeline triggering and stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ include:
       # always run on scheduled/nightly or tag pipelines
       - if: '$CI_PIPELINE_SOURCE == "schedule"'
       - if: '$CI_PIPELINE_SOURCE == "tag"'
-      - if: '$CI_COMMIT_BRANCH == "merge_request_event"'
+      - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       # run when any application-relevant file changed
       - changes:
           - src/**/*

--- a/ci/website.yml
+++ b/ci/website.yml
@@ -1,9 +1,6 @@
 default:
   interruptible: true
 
-stages:
-  - deploy
-
 variables:
   GIT_STRATEGY: clone
 


### PR DESCRIPTION
## Summary
- ensure the application pipeline is always included for merge request pipelines by checking the pipeline source instead of the branch name
- remove the stage declaration from the website pipeline so it no longer overwrites the application stage list and prevents jobs such as Configure Build from validating

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df07e09e4832bb3983c75954e94d1)