### PR TITLE
Clarify sigma-clipped mean stacking defaults

### DIFF
--- a/website/content/en/docs/v1.0/reference/modules/stack.md
+++ b/website/content/en/docs/v1.0/reference/modules/stack.md
@@ -100,8 +100,11 @@ class CheckShape,CheckAlign,FirstSub test
 1. Add the aligned (if requested) sub to the stack.
 2. Generate a new image containing the stacking result according to the configured mode.
 
-When working in **mean** mode, ALS automatically removes transient bright artefacts such as satellite trails by
-detecting and clipping per-pixel outliers using a running mean with variance estimated via Welford’s online algorithm.
+When working in **mean/AVERAGE** mode (sigma-clipped averaging), ALS automatically removes transient bright artefacts
+such as satellite trails by detecting and clipping per-pixel outliers. The stacker keeps a Welford-based running mean
+and variance for every pixel, and once at least **3** frames have been accumulated it clips any new pixel sample that
+lies above the previous mean plus **2.5σ**. Clipped values are replaced by that threshold before the running
+statistics are updated, providing single-pass, per-frame rejection without extra iterations.
 
 # Output
 

--- a/website/content/fr/docs/v1.0/reference/modules/stack.md
+++ b/website/content/fr/docs/v1.0/reference/modules/stack.md
@@ -100,8 +100,7 @@ flowchart LR
 1. Ajout de la brute alignée (si demandé) à la pile
 2. Génération d'une nouvelle image contenant le résultat de l'empilement selon le mode configuré
 
-En mode **moyenne**, ALS supprime automatiquement les artefacts lumineux transitoires (par ex. traînées de satellites) en détectant et en tronquant les valeurs aberrantes par pixel
-en utilisant une moyenne glissante avec la variance estimée par l'algorithme en ligne de Welford.
+En mode **moyenne** (**AVERAGE**), ALS effectue une moyenne avec rejet sigma-clippé pour supprimer les artefacts lumineux transitoires comme les traînées de satellites. Chaque pixel conserve une moyenne et une variance glissantes basées sur l'algorithme en ligne de Welford, et dès qu'au moins **3** brutes sont accumulées, toute nouvelle valeur de pixel dépassant la moyenne précédente de plus de **2,5σ** est tronquée à ce seuil avant la mise à jour des statistiques. Ce rejet par pixel se fait en un seul passage, sans itérations supplémentaires.
 
 # Sortie
 


### PR DESCRIPTION
## Summary
- describe mean/AVERAGE mode as sigma-clipped averaging
- document per-pixel clipping defaults and Welford-based running statistics
- update the French documentation to reflect the same sigma-clipping details

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f465083f4832b9b82741e54e08a26)