### PR TITLE
Update reference docs for sigma-clipped stacking

### DIFF
--- a/website/content/en/docs/v1.0/reference/_index.md
+++ b/website/content/en/docs/v1.0/reference/_index.md
@@ -19,3 +19,6 @@ This section contains detailed documentation about ALS bits and bolts
 🧠 It elaborates on the [concepts](../userguide/concepts) introduced at the beginning of the user guide
 {{% /alert %}}
 
+The [Stacker module](modules/stack) reference documents the sigma-clipped outlier rejection applied when stacking in
+**mean/AVERAGE** mode so you can quickly spot how transient artefacts are removed.
+

--- a/website/content/en/docs/v1.0/releasenotes/_index.md
+++ b/website/content/en/docs/v1.0/releasenotes/_index.md
@@ -15,6 +15,7 @@ weight: 100550
 ### New Features
 
 - Flat frame calibration
+- Sigma-clipped outlier rejection when stacking in **mean/AVERAGE** mode to automatically remove satellite trails and other transient artefacts
 
 ---
 

--- a/website/content/en/docs/v1.0/userguide/concepts.md
+++ b/website/content/en/docs/v1.0/userguide/concepts.md
@@ -173,6 +173,8 @@ The **Stacker** module maintains the **stack** and processes each calibrated sub
     - Adds the sub to the current stack.
     - Generates the stacking result based on the mode chosen by the user (_mean or sum_)
 
+    ⚙️ _In **mean/AVERAGE** mode, ALS performs sigma-clipped averaging: after at least **3** subs, any new pixel that rises above the previous mean by more than **2.5σ** is clipped to that threshold, which removes transient trails (e.g., satellites) before updating the running statistics._
+
 {{% alert color="info" %}}
 ℹ️ Alignment is based on the search for star groups in the compared images. ALS can only align deep sky images. **Planet or Moon images cannot be aligned**.
 {{% /alert %}}

--- a/website/content/en/docs/v1.0/userguide/ui/controls/_index.md
+++ b/website/content/en/docs/v1.0/userguide/ui/controls/_index.md
@@ -125,6 +125,8 @@ The **stack** section of the panel controls the **Stacker** module.
 
       ⚙️ _The value of each pixel in the generated stack is the **average value** of that pixel across all subs in the **stack**._
 
+      ℹ️ _Outliers are rejected automatically: once at least **3** subs are present, any new pixel above the running mean by more than **2.5σ** is clipped before contributing, which removes satellite trails and other transient artefacts in **AVERAGE** mode._
+
     - `sum`
 
       Used for creating star trails or circumpolar images.

--- a/website/content/fr/docs/v1.0/reference/_index.md
+++ b/website/content/fr/docs/v1.0/reference/_index.md
@@ -16,6 +16,9 @@ weight: 100340
 Cette section contient la documentation détaillée de tous les rouages d'ALS
 
 {{% alert color="info" %}}
-🧠 Elle développe les [concepts](/docs/v0.7/userguide/concepts) introduits au début du guide de l'utilisateur
+🧠 Elle développe les [concepts](../userguide/concepts) introduits au début du guide de l'utilisateur
 {{% /alert %}}
+
+La documentation du [module Stacker](modules/stack) décrit le rejet sigma-clippé appliqué lors de l'empilement en
+mode **moyenne/AVERAGE** afin de supprimer automatiquement les artefacts transitoires.
 

--- a/website/content/fr/docs/v1.0/releasenotes/_index.md
+++ b/website/content/fr/docs/v1.0/releasenotes/_index.md
@@ -15,6 +15,7 @@ weight: 100550
 ### Nouveautés
 
 - Calibration par flat
+- Rejet sigma-clippé des valeurs aberrantes lors de l'empilement en mode **moyenne/AVERAGE** pour supprimer automatiquement les traînées de satellites et autres artefacts transitoires
 
 ---
 

--- a/website/content/fr/docs/v1.0/userguide/concepts.md
+++ b/website/content/fr/docs/v1.0/userguide/concepts.md
@@ -176,6 +176,8 @@ Le module **Stacker** maintient la **stack** et prend en charge les traitements 
     - Ajoute la brute à la **stack**
     - Génère le résultat de l'empilement en fonction du mode choisi par vous (_moyenne ou somme_)
 
+    ⚙️ _En mode **moyenne/AVERAGE**, ALS applique une moyenne avec rejet sigma-clippé : dès qu'au moins **3** brutes sont disponibles, tout nouveau pixel dépassant la moyenne précédente de plus de **2,5σ** est ramené à ce seuil, ce qui supprime les traînées transitoires (ex. satellites) avant la mise à jour des statistiques glissantes._
+
 {{% alert color="info" %}}
 ℹ️ L'alignement est basé sur la recherche de groupes d'étoiles dans les brutes comparées. ALS ne peut donc aligner que
 des images du ciel profond. **Les images de planètes ou de la Lune ne peuvent pas être alignées**.

--- a/website/content/fr/docs/v1.0/userguide/ui/controls/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/controls/_index.md
@@ -121,10 +121,12 @@ La section **stack** du panneau contrôle le module **Stacker**.
 - Utilisez la liste déroulante pour définir le **mode d'empilement** à utiliser :
     - `moyenne`
 
-      Utilisé pour le visuel assisté ou la surveillance d'une série d'acquisitions 
+      Utilisé pour le visuel assisté ou la surveillance d'une série d'acquisitions
 
       ⚙️ _La valeur de chaque pixel de l'empilement généré est la **valeur moyenne** de ce pixel sur toutes
       les brutes de la **stack**_.
+
+      ℹ️ _Les valeurs aberrantes sont rejetées automatiquement : dès qu'au moins **3** brutes sont présentes, tout nouveau pixel dépassant la moyenne courante de plus de **2,5σ** est tronqué avant de contribuer, ce qui supprime les traînées de satellites et autres artefacts transitoires en mode **AVERAGE**._
 
     - `somme`
 


### PR DESCRIPTION
## Summary
- highlight sigma-clipped outlier rejection for mean/AVERAGE stacking in the v1.0 reference section
- fix the French reference index to point to the v1.0 concepts page

## Testing
- not run (documentation only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4a7647d4832ba90e2faef27e4c83)