### PR TITLE
Remove tag updates from v0.7 docs

### DIFF
--- a/website/content/en/docs/v1.0/releasenotes/_index.md
+++ b/website/content/en/docs/v1.0/releasenotes/_index.md
@@ -4,7 +4,7 @@ description: ALS Release Notes
 author: ALS Team
 lastmod: 2025-11-20T18:04:55Z
 keywords: [ 'ALS Release Notes' ]
-tags: [ ]
+tags: [ 'release notes', 'changelog' ]
 weight: 100550
 ---
 

--- a/website/content/en/docs/v1.0/userguide/preferences/_index.md
+++ b/website/content/en/docs/v1.0/userguide/preferences/_index.md
@@ -7,7 +7,7 @@ keywords: ["ALS settings", "ALS preferences"]
 draft: false
 type: "docs"
 categories: ["configuration"]
-tags: [ ]
+tags: [ "preferences", "settings" ]
 weight: 100330
 ---
 

--- a/website/content/en/docs/v1.0/userguide/ui/menu/_index.md
+++ b/website/content/en/docs/v1.0/userguide/ui/menu/_index.md
@@ -7,7 +7,7 @@ lastmod: 2025-11-07T14:54:31Z
 keywords: ["ALS Menu"]
 type: "docs"
 categories: ["usage"]
-tags: [ ]
+tags: [ "menu", "navigation" ]
 weight: 100325
 ---
 

--- a/website/content/en/docs/v1.0/userguide/ui/shortcuts.md
+++ b/website/content/en/docs/v1.0/userguide/ui/shortcuts.md
@@ -8,7 +8,7 @@ keywords: [ "keyboard shortcuts", "shortcuts" ]
 draft: false
 type: "docs"
 categories: [ "usage" ]
-tags: [ "" ]
+tags: [ "keyboard shortcuts", "hotkeys" ]
 weight: 100324
 ---
 

--- a/website/content/fr/docs/v1.0/releasenotes/_index.md
+++ b/website/content/fr/docs/v1.0/releasenotes/_index.md
@@ -4,7 +4,7 @@ description: Notes de version d'ALS
 author: ALS Team
 lastmod: 2025-11-20T18:04:55Z
 keywords: [ 'Notes de version ALS' ]
-tags: [ ]
+tags: [ 'notes de version', 'journal des modifications' ]
 weight: 100550
 ---
 

--- a/website/content/fr/docs/v1.0/userguide/preferences/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/preferences/_index.md
@@ -6,7 +6,7 @@ lastmod: 2025-11-02T19:02:52Z
 keywords: ["préférences ALS"]
 type: "docs"
 categories: ["configuration"]
-tags: [ ]
+tags: [ "préférences", "configuration" ]
 weight: 100330
 ---
 

--- a/website/content/fr/docs/v1.0/userguide/ui/menu/_index.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/menu/_index.md
@@ -7,7 +7,7 @@ lastmod: 2025-11-07T14:54:32Z
 keywords: ["ALS Menu"]
 type: "docs"
 categories: ["utilisation"]
-tags: [ ]
+tags: [ "menu", "navigation" ]
 weight: 100325
 ---
 

--- a/website/content/fr/docs/v1.0/userguide/ui/shortcuts.md
+++ b/website/content/fr/docs/v1.0/userguide/ui/shortcuts.md
@@ -8,7 +8,7 @@ keywords: [ "raccourcis clavier", "shortcuts" ]
 draft: false
 type: "docs"
 categories: [ "utilisation" ]
-tags: [ "" ]
+tags: [ "raccourcis clavier", "touches de raccourci" ]
 weight: 100324
 ---
 


### PR DESCRIPTION
## Summary
- revert the v0.7 release notes, preferences, menu, and shortcuts pages to their original empty tag arrays
- keep the v1.0 documentation tag updates from the previous change intact

## Testing
- not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f6be0498832bb3fa1479f4d2c853)